### PR TITLE
Fixes a bug in complex_promotion(x, Type) and in complex_promotion(x,…

### DIFF
--- a/src/algebraic.cc
+++ b/src/algebraic.cc
@@ -273,14 +273,14 @@ bool algebraic::complex_promotion(algebraic_g &x, object::id type)
     {
         // Convert from polar to rectangular
         polar_g z = polar_p(algebraic_p(x));
-        x = polar_p(z->as_polar());
+        x = rectangular_p(z->as_rectangular());
         return x.Safe();
     }
     else if (xt == ID_rectangular)
     {
         // Convert from rectangular to polar
         rectangular_g z = rectangular_p(algebraic_p(x));
-        x = rectangular_p(z->as_rectangular());
+        x = polar_p(z->as_polar());
         return x.Safe();
     }
     else if (is_strictly_symbolic(xt))

--- a/src/arithmetic.cc
+++ b/src/arithmetic.cc
@@ -92,21 +92,16 @@ bool arithmetic::complex_promotion(algebraic_g &x, algebraic_g &y)
     id xt = x->type();
     id yt = y->type();
 
+    // If both are complex, we do not do anything: Complex ops know best how
+    // to handle mixed inputs (mix of rectangular and polar). We should leave
+    // it to them to handle the different representations.
+    if (is_complex(xt) && is_complex(yt)) return true;
+
+    // Try to convert both types to the same complex type
     if (is_complex(xt))
-    {
-        // Success if the two complex types are identical
-        if (yt == xt)
-            return true;
-
-        // Try to convert both types to the same complex type
         return complex_promotion(y, xt);
-    }
-
     if (is_complex(yt))
-    {
-        // Try to convert both types to the same complex type
         return complex_promotion(x, yt);
-    }
 
     // Neither type is complex, no point to promote
     return false;


### PR DESCRIPTION
… y),

which together were still resulting in the desired behavior. Specifically, complex_promotion(x, Type) was a no-op when x was already a complex (even if not with type Type). We are changing this so that x is converted to the other complex representation if needed. Conversely, we are changing the complex_promotion(x, y) implementation, so that it does not force x and y to have the same complex representation when they are both already complex numbers. This is because we should defer to the actual op evaluation to decide how to best handle them the mix of argument representations.

In other words, we fixed complex_promotion(x, Type) for the case where x is already a complex, but we also updated complex_promotion(x, y) so that it does not rely on that case anymore.