### PR TITLE
Fixed problem in simulator missing quick mouse clicks

### DIFF
--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -543,7 +543,8 @@ bool MainWindow::eventFilter(QObject * obj, QEvent * ev)
             return true;
         }
 
-        if (ev->type() == QEvent::MouseButtonPress)
+        if (ev->type() == QEvent::MouseButtonPress ||
+            ev->type() == QEvent::MouseButtonDblClick)
         {
             QMouseEvent *me = static_cast < QMouseEvent * >(ev);
 #if QT_VERSION < 0x060000


### PR DESCRIPTION
This pull-request fixes a problem in the DB48X simulator.
If two mouse clicks are issued quickly, the second one has the type QEvent::MouseButtonDblClick.
This leads to the event being ignored. This is now fixed.