### PR TITLE
Fix simulator crash in stopBuzzer

### DIFF
--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -621,7 +621,8 @@ void MainWindow::stopBuzzer()
 {
     delete audiobuf;
     audiobuf = nullptr;
-    audio->stop();
+    if (audio)
+        audio->stop();
 }
 
 


### PR DESCRIPTION
This fixes a crash in the DB48X simulator when the buzzer is stopped.
I only have the problem on a Ubuntu build of the simulator. A MacOS build does not crash.
 