### PR TITLE
Update sim-window.ui toget a bigger proportional look of the simulator

### DIFF
--- a/sim/sim-window.ui
+++ b/sim/sim-window.ui
@@ -51,8 +51,8 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>66</width>
-            <height>46</height>
+            <width>443</width>
+            <height>707</height>
            </size>
           </property>
           <property name="maximumSize">


### PR DESCRIPTION
At least on WSL on Windows11, the calculator starts in a very small windows.