### PR TITLE
stack: Fix display of hash in interactive stack

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -4634,7 +4634,7 @@ bool user_interface::handle_editing(int key)
                         snprintf(sizebuf, sizeof(sizebuf), "%lu bytes %s",
                                  (unsigned long) size, obj->fancy());
                         size_t len = bin->render(valbuf, sizeof(valbuf) - 1);
-                        valbuf[len] = '\0';
+                        valbuf[len] = 0;
                         draw_message("Object info", sizebuf, valbuf);
                         wait_for_key_press();
                     }

--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -4633,7 +4633,8 @@ bool user_interface::handle_editing(int key)
                         char valbuf[40];
                         snprintf(sizebuf, sizeof(sizebuf), "%lu bytes %s",
                                  (unsigned long) size, obj->fancy());
-                        bin->render(valbuf, sizeof(valbuf));
+                        size_t len = bin->render(valbuf, sizeof(valbuf) - 1);
+                        valbuf[len] = '\0';
                         draw_message("Object info", sizebuf, valbuf);
                         wait_for_key_press();
                     }


### PR DESCRIPTION
`draw_message()` expects zero-terminated strings, the rendered hash value in `valbuf` was not and could cause random characters to appear after it, which lead to failing the
"istack: Interactive stack info about 5" test.

Zero-terminate `valbuf`.

Fixes #1541 

(Sorry for the force push, forgot to create a new branch for a different fix.)