### PR TITLE
stats: Fix `nullptr` dereference in `standard_deviation()` et al

### DIFF
--- a/src/stats.cc
+++ b/src/stats.cc
@@ -985,10 +985,13 @@ algebraic_p StatsAccess::standard_deviation() const
 //   Compute the standard deviation
 // ----------------------------------------------------------------------------
 {
-    algebraic_g var = variance();
-    if (array_p vara = var->as<array>())
-        return vara->map(sqrt::evaluate);
-    return sqrt::evaluate(var);
+    if (algebraic_g var = variance())
+    {
+        if (array_p vara = var->as<array>())
+            return vara->map(sqrt::evaluate);
+        return sqrt::evaluate(var);
+    }
+    return nullptr;
 }
 
 
@@ -1271,10 +1274,13 @@ algebraic_p StatsAccess::population_standard_deviation() const
 //   Compute the population variance
 // ----------------------------------------------------------------------------
 {
-    algebraic_g pvar = population_variance();
-    if (array_p pvara = pvar->as<array>())
-        return pvara->map(sqrt::evaluate);
-    return sqrt::evaluate(pvar);
+    if (algebraic_g pvar = population_variance())
+    {
+        if (array_p pvara = pvar->as<array>())
+            return pvara->map(sqrt::evaluate);
+        return sqrt::evaluate(pvar);
+    }
+    return nullptr;
 }
 
 


### PR DESCRIPTION
`variance()` and `population_variance()` can return a `nullptr` which was not checked for by `standard_deviation()` and `population_standard_deviation()` and than led to a crash.

Simple test cases are `ClearΣ StandardDeviation` and `ClearΣ PopulationStandardDeviation`.