### PR TITLE
Fix issue 1529: move Temperature and Pressure units to separate (sub)menus

### DIFF
--- a/src/tests.cc
+++ b/src/tests.cc
@@ -5902,7 +5902,11 @@ void tests::units_and_conversions()
         .editor("1_km/h")
         .test(ENTER)
         .type(ID_unit).expect("1 km/h")
-        .test(KEY1, F1, SHIFT, KEY5, SHIFT, F1, RSHIFT, F2)
+        .test(KEY1,        // 1
+              F1,          // in
+              SHIFT, KEY5, // UNIT menu
+              SHIFT, F2,   // Time menu
+              RSHIFT, F2)  // inverse(min)
         .editor("1_in/(min)")
         .test(ENTER)
         .type(ID_unit).expect("1 in/min")
@@ -5914,18 +5918,48 @@ void tests::units_and_conversions()
         .test(ENTER).expect("42 km/h")
         .test(RSHIFT, KEY5, F5).expect("37 km/h");
     step("Factoring out a unit")
-        .test(CLEAR, KEY3, SHIFT, KEY5, SHIFT, F6, F2, ENTER).expect("3 kW")
-        .test(KEY1, SHIFT, KEY5, SHIFT, F4, F1, ENTER).expect("1 N")
+        .test(CLEAR,
+              KEY3,        // 3
+              SHIFT, KEY5, // UNIT menu
+              RSHIFT, F2,  // Power menu
+              F2,          // kW
+              ENTER)
+        .expect("3 kW")
+        .test(KEY1,        // 1
+              SHIFT, KEY5, // UNIT menu
+              SHIFT, F5,   // Force menu
+              F1,          // N
+              ENTER)
+        .expect("1 N")
         .test(RSHIFT, KEY5, F4).expect("3 000 N·m/s");
     step("Orders of magnitude")
-        .test(CLEAR, KEY3, SHIFT, KEY5, SHIFT, F6, F2, ENTER).expect("3 kW")
+        .test(CLEAR,
+              KEY3,        // 3
+              SHIFT, KEY5, // UNIT menu
+              RSHIFT, F2,  // Power menu
+              F2,          // kW
+              ENTER)
+        .expect("3 kW")
         .test(RSHIFT, KEY5, SHIFT, F2).expect("300 000 cW")
         .test(LSHIFT, F3).expect("3 kW")
         .test(LSHIFT, F4).expect("³/₁ ₀₀₀ MW");
     step("Unit simplification (same unit)")
-        .test(CLEAR, KEY3, SHIFT, KEY5, SHIFT, F6, F2, ENTER).expect("3 kW")
-        .test(SHIFT, KEY5, SHIFT, F4, F1).expect("3 kW·N")
-        .test(SHIFT, KEY5, SHIFT, F6, RSHIFT, F2, ENTER).expect("3 N");
+        .test(CLEAR,
+              KEY3,        // 3
+              SHIFT, KEY5, // UNIT menu
+              RSHIFT, F2,  // Power menu
+              F2,          // kW
+              ENTER)
+        .expect("3 kW")
+        .test(SHIFT, KEY5, // UNIT menu
+              SHIFT, F5,   // Force menu
+              F1)          // N
+        .expect("3 kW·N")
+        .test(SHIFT, KEY5, // UNIT menu
+              RSHIFT, F2,  // Power menu
+              RSHIFT, F2,  // inverse(kW)
+              ENTER)
+        .expect("3 N");
     step("Arithmetic on units")
         .test(CLEAR, KEY3, KEY7, SHIFT, KEY5, F2, F4, ENTER).expect("37 mph")
         .test(SHIFT, KEY5, KEY4, KEY2, F2, F3, ENTER).expect("42 km/h")
@@ -5996,7 +6030,7 @@ void tests::units_and_conversions()
         .expect("⁴⁵ ³⁵⁹ ²³⁷/₅₀ ₀₀₀ ₀₀₀ kg")
         .test(CLEAR,
               LSHIFT, KEY5,     // Units menu
-              LSHIFT, F3,       // Select Mass
+              LSHIFT, F4,       // Select Mass
               KEY2, F6, F1,     // Enter 2_lb
               LSHIFT, F6,       // Previous page
               LSHIFT, F1)       // Convert to kg

--- a/src/unit.cc
+++ b/src/unit.cc
@@ -673,24 +673,6 @@ static const cstring basic_units[] =
     // ------------------------------------------------------------------------
     "Fluids",    nullptr,
 
-    "K",        "1_K",                  // Kelvin
-    "°C",       "'(°C+273.15)'_K",      // Celsius
-    "°R",       "5/9_K",                // Rankin
-    "°F",       "'((°F+459.67)*5/9)'_K",// Fahrenheit
-    "°D",       "'(373.15-2/3*°D)'_K",  // Delisle
-
-    "Pa",       "1_N/m^2",              // Pascal
-    "atm",      "101325_Pa",            // Atmosphere
-    "bar",      "100000_Pa",            // bar
-    "psi",      "6894.75729317_Pa",     // Pound per square inch
-    "ksi",      "1000_psi",             // Kilopound per square inch
-
-    "kPa",      "=",                    // Kilopascal
-    "mmHg",     "1_torr",               // millimeter of mercury
-    "inHg",     "1_in/mm*mmHg",         // inch of mercury
-    "inH2O",    "249.0889_Pa",          // Inch of H2O
-    "torr",     "1/760_atm",            // Torr = 1/760 standard atm
-
     "m³/yr",    "=",                    // Cubic meters per year
     "m³/d",     "=",                    // Cubic meters per day
     "m³/h",     "=",                    // Cubic meters per hour
@@ -810,6 +792,30 @@ static const cstring basic_units[] =
     "Tflops",   "=",
     "Pflops",   "=",
     "Eflops",   "=",
+
+
+    "Temperature", nullptr,
+
+    "K",        "1_K",                  // Kelvin
+    "°C",       "'(°C+273.15)'_K",      // Celsius
+    "°R",       "5/9_K",                // Rankin
+    "°F",       "'((°F+459.67)*5/9)'_K",// Fahrenheit
+    "°D",       "'(373.15-2/3*°D)'_K",  // Delisle
+
+
+    "Pressure", nullptr,
+
+    "Pa",       "1_N/m^2",              // Pascal
+    "atm",      "101325_Pa",            // Atmosphere
+    "bar",      "100000_Pa",            // bar
+    "psi",      "6894.75729317_Pa",     // Pound per square inch
+    "ksi",      "1000_psi",             // Kilopound per square inch
+
+    "kPa",      "=",                    // Kilopascal
+    "mmHg",     "1_torr",               // millimeter of mercury
+    "inHg",     "1_in/mm*mmHg",         // inch of mercury
+    "inH2O",    "249.0889_Pa",          // Inch of H2O
+    "torr",     "1/760_atm",            // Torr = 1/760 standard atm
 };
 
 


### PR DESCRIPTION
The units for Pressure where hard to find.
They where hidden in the Fluids (flow) menu.
That contained Temperature units as well.

Moved both the Pressere and Temperature units to their own menu.

That cauese several tests to fail because the units (sub)menus get rearranged. The failing tests are adjusted (and commented).

Fixes: #1529