### PR TITLE
fix issue 1517: improve Udefine and Upurge documentation

### DIFF
--- a/doc/commands/units.md
+++ b/doc/commands/units.md
@@ -1,24 +1,29 @@
 # Operations with Units
 
 ## UDEFINE
-Create a user-defined unit
+Create a user-defined unit.
+
+This command is not implemented (yet; it is inherited from newRPL, not from HP 49g / 50g). As a workaround you can add user-defined units to the [Units file](#Units file).
 
 
 ## UPURGE
-Delete a user-defined unit
+Delete a user-defined unit.
+
+This command is not implemented (yet; see [UDEFINE](#UDEFINE)).
 
 
 ## UnitValue
 
 Return the numeric part of a unit object.
 
-`3_km`  ▶ `3`
+`3_km` ▶ `3`
+
 
 ## BaseUnits
 
 Expand all unit factors to their base units.
 
-`3_km`  ▶ `3000_m`
+`3_km` ▶ `3000_m`
 
 
 ## Convert
@@ -26,7 +31,6 @@ Expand all unit factors to their base units.
 Convert value from one unit to another. This convert the values in the second level of the stack to the unit of the object in the first level of the stack. Only the unit in the first level of the stack is being considered, the actual value is ignored. For example:
 
 `3_km` `2_m` ▶ `3000_m`
-
 
 
 ## FactorUnit


### PR DESCRIPTION
The implementation status and use of the commands Udefine and Upurge was unclear. Their status is explained and a workaround documented.

Fixed a few other typos.

Fixes: #1517
