### PR TITLE
Fix issue 1515: ToUncertain command no longer sorts its arguments

### DIFF
--- a/doc/commands/ranges.md
+++ b/doc/commands/ranges.md
@@ -56,12 +56,14 @@ Input values are sorted so that the range is normalized.
 ```
 ## →σRange
 
-Build an uncertain number ( `a±b%`) out of two individual
-components for the low and high value.
+Build an uncertain number (range of the form `a±σb`) out of two individual
+components for the mean and standard deviation value.
+
+Input values are not sorted (a large mean may have a smaller standard deviation).
 
 ```rpl
-1 2 →σRange
-@ Expecting 1±σ2
+100 2 →σRange
+@ Expecting 100±σ2
 ```
 
 

--- a/src/range.cc
+++ b/src/range.cc
@@ -898,7 +898,13 @@ static object::result to_range(object::id ty)
         rt.type_error();
         return object::ERROR;
     }
-    range::sort(lo, hi);
+    // The calculator user may put the lo(w) and hi(gh) values for a range in the wrong order.
+    // As a nice gesture they are sorted. That's convenient for most range types.
+    // But for an uncertain number they aren't lo(w) and hi(gh) values.
+    // They are mean and standard deviation.
+    // Sorting those is very likely incorrect. It should not be done.
+    if(! (ty == uncertain::ID_uncertain))
+        range::sort(lo, hi);
     range_g r = range::make(ty, lo, hi);
     if (!r || !rt.drop() || !rt.top(r))
         return object::ERROR;


### PR DESCRIPTION
The ToUncertain command, just like the other To... range commands, sorted its arguments. That's not correct for this type. It now no longer sorts its arguments.

The documentation was incorrect. Changed accordingly.

Fixes: #1515