### PR TITLE
ui: Delay setting of `lowercase` for transient alpha mode

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -128,6 +128,7 @@ user_interface::user_interface()
       xshift(false),
       alpha(false),
       transalpha(false),
+      talphaLowerc(false),
       lowercase(false),
       userOnce(false),
       shiftDrawn(false),
@@ -4321,7 +4322,7 @@ bool user_interface::handle_shifts(int &key, bool talpha)
 
                 last = key;
                 repeat = true;
-                lowercase = key == KEY_DOWN;
+                talphaLowerc = key == KEY_DOWN;
                 return true;
             }
             else if (key)
@@ -4329,6 +4330,7 @@ bool user_interface::handle_shifts(int &key, bool talpha)
                 // A non-arrow key was pressed while arrows are down
                 alpha = true;
                 transalpha = true;
+                lowercase = talphaLowerc;
                 last = 0;
                 return false;
             }

--- a/src/user_interface.h
+++ b/src/user_interface.h
@@ -303,6 +303,7 @@ protected:
     bool     xshift       : 1;  // Extended shift active (simulate Right)
     bool     alpha        : 1;  // Alpha mode active
     bool     transalpha   : 1;  // Transitory alpha (up or down key)
+    bool     talphaLowerc : 1;  // Transitory alpha is lowercase
     bool     lowercase    : 1;  // Lowercase
     bool     userOnce     : 1;  // User mode should be reset
     bool     shiftDrawn   : 1;  // Cache of drawn annunciators


### PR DESCRIPTION
When using the simulator, every time the left/right keys are used in alpha mode, the case is switched to upper/lower.

Fix this by delaying the setting of `lowercase` until a key is pressed after holding down the left/right key to activate transient alpha mode.

Fixes #1329 ???

I can't test this on a device since I don't have one.