### PR TITLE
ui: Make transitory alpha work in alpha mode and delay lowercase

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -127,8 +127,11 @@ user_interface::user_interface()
       shift(false),
       xshift(false),
       alpha(false),
-      transalpha(false),
       lowercase(false),
+      transalpha(false),
+      taLowercase(false),
+      taPrevAlpha(false),
+      taPrevLowerc(false),
       userOnce(false),
       shiftDrawn(false),
       xshiftDrawn(false),
@@ -4321,14 +4324,17 @@ bool user_interface::handle_shifts(int &key, bool talpha)
 
                 last = key;
                 repeat = true;
-                lowercase = key == KEY_DOWN;
+                taLowercase = key == KEY_DOWN;
                 return true;
             }
             else if (key)
             {
                 // A non-arrow key was pressed while arrows are down
-                alpha = true;
                 transalpha = true;
+                taPrevAlpha = alpha;
+                taPrevLowerc = lowercase;
+                alpha = true;
+                lowercase = taLowercase;
                 last = 0;
                 return false;
             }
@@ -4354,8 +4360,8 @@ bool user_interface::handle_shifts(int &key, bool talpha)
         {
             // We released the up/down key
             transalpha = false;
-            alpha = false;
-            lowercase = false;
+            alpha = taPrevAlpha;
+            lowercase = taPrevLowerc;
             key = 0;
             last = 0;
             return true;

--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -570,7 +570,7 @@ bool user_interface::editor_history(bool back)
             rt.edit(+ed, sz);
             cursor = 0;
             select = ~0U;
-            alpha = xshift = shift = false;
+            alpha = lowercase = xshift = shift = false;
             edRows = 0;
             dirtyEditor = true;
             break;
@@ -2265,7 +2265,7 @@ bool user_interface::draw_annunciators()
                 "", "ABC", "abc", "abc",
                 "USR", "αUS", "usr", "αus",
                 "", "ABC", "abc", "abc",
-                "1US", "α1U", "1u", "α1u"
+                "1US", "α1U", "1us", "α1u"
             };
             utf8 label = utf8(lbls[alpha + 2*lowercase + 4*user + 8*userOnce]);
             pattern apat = lowercase
@@ -4107,7 +4107,7 @@ bool user_interface::handle_screen_capture(int key)
     {
         if (key == KEY_SCREENSHOT)
         {
-            shift = xshift = alpha = longpress = repeat = false;
+            shift = xshift = alpha = lowercase = longpress = repeat = false;
             last = 0;
             draw_annunciators();
             refresh_dirty();
@@ -4360,8 +4360,13 @@ bool user_interface::handle_shifts(int &key, bool talpha)
         {
             // We released the up/down key
             transalpha = false;
-            alpha = taPrevAlpha;
-            lowercase = taPrevLowerc;
+            // Restore alpha/lowercase mode unless alpha mode was exited
+            // while in trans-alpha mode
+            if (alpha)
+            {
+                alpha = taPrevAlpha;
+                lowercase = taPrevLowerc;
+            }
             key = 0;
             last = 0;
             return true;
@@ -4421,10 +4426,7 @@ bool user_interface::handle_shifts(int &key, bool talpha)
                 lowercase = true;
         }
         else
-        {
-            alpha     = true;
-            lowercase = false;
-        }
+            alpha = true;
         consumed = true;
         shift = false;
         key = last = 0;
@@ -5725,7 +5727,10 @@ bool user_interface::handle_functions(int key, object_p objp, bool user)
     draw_idle();
     dirtyStack = true;
     if (!imm && (!validate_input || mode != TEXT))
+    {
         alpha = false;
+        lowercase = false;
+    }
     xshift = false;
     shift = false;
 
@@ -6427,7 +6432,7 @@ bool user_interface::do_search(unicode with, bool restart)
 
 bool user_interface::editor_search()
 // ----------------------------------------------------------------------------
-//   Start or repeat a search a search
+//   Start or repeat a search
 // ----------------------------------------------------------------------------
 {
     if (~select && cursor != select)
@@ -6445,7 +6450,6 @@ bool user_interface::editor_search()
         // Start search
         searching = select = cursor;
         alpha = true;
-        lowercase = false;
         shift = xshift = false;
     }
     return true;

--- a/src/user_interface.h
+++ b/src/user_interface.h
@@ -302,8 +302,11 @@ protected:
     bool     shift        : 1;  // Normal shift active
     bool     xshift       : 1;  // Extended shift active (simulate Right)
     bool     alpha        : 1;  // Alpha mode active
-    bool     transalpha   : 1;  // Transitory alpha (up or down key)
     bool     lowercase    : 1;  // Lowercase
+    bool     transalpha   : 1;  // Transitory alpha (up or down key)
+    bool     taLowercase  : 1;  // Lowercase transitory alpha
+    bool     taPrevAlpha  : 1;  // Alpha mode before transitory alpha
+    bool     taPrevLowerc : 1;  // Lowercase before transitory alpha
     bool     userOnce     : 1;  // User mode should be reset
     bool     shiftDrawn   : 1;  // Cache of drawn annunciators
     bool     xshiftDrawn  : 1;  // Cache


### PR DESCRIPTION
Remember alpha/lowercase state when invoking transitory alpha and restore them after transitory alpha mode ends.

Also delay setting of `lowercase` until the first key press after holding down the transitory alpha activators.

Before this the arrow keys would switch between upper/lower case while editing in the simulator. Also using Shift/Alt on the simulator now properly reverts to the previous case and will not end alpha mode.

Fixes #1329 ???

I can't test this on a device since I don't have one.