### PR TITLE
ui: Fix user mode menu flag marker and annuciator display

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -768,6 +768,7 @@ void user_interface::toggle_user()
     {
         Settings.UserMode(false);
     }
+    menu_refresh(menu::ID_UserModeMenu);
 }
 
 
@@ -5583,7 +5584,11 @@ bool user_interface::handle_functions(int key, object_p objp, bool user)
         utf8 txt = direct->value(&sz);
         bool result = insert(txt, sz, TEXT) == object::OK;
         if (userOnce)
+        {
+            userOnce = false;
             Settings.UserMode(false);
+            menu_refresh(menu::ID_UserModeMenu);
+        }
         return result;
     }
 
@@ -5724,7 +5729,11 @@ bool user_interface::handle_functions(int key, object_p objp, bool user)
     shift = false;
 
     if (userOnce && usr == Settings.UserMode())
+    {
+        userOnce = false;
         Settings.UserMode(false);
+        menu_refresh(menu::ID_UserModeMenu);
+    }
     return true;
 }
 


### PR DESCRIPTION
`ToggleUserMode` didn't update the user mode flag marker when the user mode menu was displayed.

Also when one key user mode was active and then `UserModeLock` was set the next user mode activation would indicate one key user mode ("1US" ...) in the display annunciator even if it was actually locked user mode.

Fix this by redrawing the user mode menu and explictly clearing `userOnce`.