### PR TITLE
src: fix Date+ crash in case of illegal date

### DIFF
--- a/src/datetime.cc
+++ b/src/datetime.cc
@@ -897,18 +897,10 @@ COMMAND_BODY(DateAdd)
 // ----------------------------------------------------------------------------
 {
     if (object_p d1 = rt.stack(1))
-    {
         if (object_p d2 = rt.stack(0))
-        {
             if (algebraic_p daf = days_after(d1, d2))
                 if (rt.drop() && rt.top(daf))
                     return OK;
-            if (algebraic_p daf = days_after(d2, d1))
-                if (rt.drop() && rt.top(daf))
-                    return OK;
-        }
-    }
-
     return ERROR;
 }
 


### PR DESCRIPTION
The Date+ command, when given an illegal date, only partly recovers from the error. It proceeds to the same operation with the arguments reversed and then crashes.

The functionality of reversed arguments is not documented.

Removed the code for reversed arguments.
Then the recovery of an earlier error gets completed.

Fixes: #1556
Signed-off-by: Ed@vanGasteren.net