### PR TITLE
ui: Fix variable name typo

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -1918,8 +1918,8 @@ bool user_interface::draw_header()
             changed = !rt.editing() && time - customHeaderDrawn > period;
             if (changed)
                 customHeaderDrawn = time;
-            if (time - last < remaining)
-                remaining -= time - last;
+            if (time - customHeaderDrawn < remaining)
+                remaining -= time - customHeaderDrawn;
             draw_refresh(remaining);
         }
     }


### PR DESCRIPTION
`last` holds the previous key pressed, which doesn't make much sense as a timing parameter for me, and `customHeaderDrawn` was previously named `lastt`, so probably a typo.