### PR TITLE
ui: Fix interactive stack `xshift` arrow keys

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -4310,7 +4310,10 @@ bool user_interface::handle_shifts(int &key, bool talpha)
             {
                 // Let menu and normal keys go through
                 if (xshift)
+                {
+                    last = key;
                     return false;
+                }
 
                 // Delay processing of up or down until after delay
                 if (longpress)
@@ -4342,6 +4345,9 @@ bool user_interface::handle_shifts(int &key, bool talpha)
         }
         else if (!key && (last == KEY_UP || last == KEY_DOWN))
         {
+            if (xshift)
+                return false;
+
             if (!longpress)
                 key = last;
             last = 0;


### PR DESCRIPTION
Change `handle_shifts()` to handle the arrow keys like any other key it isn't interested in when `xshift` is active.

This fixes the interactive stack where previously `xshift` wasn't cleared when using the arrow keys.

Fixes #1041
