### PR TITLE
settings: Refresh menu after `ResetModes`

### DIFF
--- a/src/settings.cc
+++ b/src/settings.cc
@@ -257,6 +257,7 @@ COMMAND_BODY(ResetModes)
 // ----------------------------------------------------------------------------
 {
     Settings = settings();
+    ui.menu_refresh();
     return OK;
 }
 


### PR DESCRIPTION
Entering the modes menu with `ModesMenu`, changing the angle mode, and than using `ResetModes` doesn't update the angle mode markers. Would also happen with any other menu showing settings markers where these settings are reset by `ResetModes`.

Fix this by refreshing the menu in `ResetModes`.