### PR TITLE
build: Add warning options for `gcc` simulator build

### DIFF
--- a/sim/db48x.pro
+++ b/sim/db48x.pro
@@ -139,6 +139,8 @@ macx:    QMAKE_CFLAGS += -fsanitize=address
 macx:    LIBS += -fsanitize=address
 clang:   QMAKE_CFLAGS   += -Wall -Wno-unknown-pragmas
 clang:   QMAKE_CXXFLAGS += -Wall -Wno-unknown-pragmas -Wno-vla-cxx-extension
+gcc:     QMAKE_CFLAGS   += -Wall -Wno-packed-bitfield-compat
+gcc:     QMAKE_CXXFLAGS += -Wall -Wno-packed-bitfield-compat
 
 OBJECTS_DIR=db48x-build
 


### PR DESCRIPTION
Enable all warnings excluding the packed bitfield layout change warning when building the simulator with `gcc`.