### PR TITLE
ui: Fix double shifted arrow key handling and shift handling simplification

### DIFF
--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -132,6 +132,7 @@ user_interface::user_interface()
       taLowercase(false),
       taPrevAlpha(false),
       taPrevLowerc(false),
+      delayedArrow(false),
       userOnce(false),
       shiftDrawn(false),
       xshiftDrawn(false),
@@ -570,7 +571,7 @@ bool user_interface::editor_history(bool back)
             rt.edit(+ed, sz);
             cursor = 0;
             select = ~0U;
-            alpha = lowercase = xshift = shift = false;
+            alpha = lowercase = shift = xshift = false;
             edRows = 0;
             dirtyEditor = true;
             break;
@@ -4323,18 +4324,20 @@ bool user_interface::handle_shifts(int &key, bool talpha)
             {
                 // Let menu and normal keys go through
                 if (xshift)
-                    return false;
-
-                // Delay processing of up or down until after delay
-                if (longpress)
                 {
-                    repeat = true;
+                    last = key;
                     return false;
                 }
 
-                last = key;
                 repeat = true;
+
+                // Delay processing of up or down until after delay
+                if (longpress)
+                    return false;
+
                 taLowercase = key == KEY_DOWN;
+                delayedArrow = true;
+                last = key;
                 return true;
             }
             else if (key)
@@ -4356,8 +4359,9 @@ bool user_interface::handle_shifts(int &key, bool talpha)
                 return true;
             }
         }
-        else if (!key && (last == KEY_UP || last == KEY_DOWN))
+        else if (!key && delayedArrow)
         {
+            delayedArrow = false;
             if (!longpress)
                 key = last;
             last = 0;
@@ -4396,34 +4400,31 @@ bool user_interface::handle_shifts(int &key, bool talpha)
     {
         if (longpress)
         {
-            alpha = !alpha;
-            lowercase = false;
-            xshift = 0;
-            shift = 0;
-        }
-        else if (xshift)
-        {
+            if (alpha)
+                alpha = lowercase = false;
+            else
+                alpha = true;
+            shift = false;
             xshift = false;
         }
         else
         {
-            xshift = false;
-#define SHM(d, x, s) ((d << 2) | (x << 1) | (s << 0))
-#define SHD(d, x, s) (1 << SHM(d, x, s))
-            // Double shift toggles xshift
-            bool dshift = last == KEY_SHIFT;
-            int  plane  = SHM(dshift, xshift, shift);
-            const unsigned nextShift =
-                SHD(0, 0, 0) | SHD(0, 1, 0) | SHD(1, 0, 0);
-            const unsigned nextXShift =
-                SHD(0, 0, 1) | SHD(0, 1, 0) | SHD(0, 1, 1) | SHD(1, 0, 1);
-            shift  = (nextShift  & (1 << plane)) != 0;
-            xshift  = (nextXShift & (1 << plane)) != 0;
+            if (xshift)
+            {
+                xshift = false;
+            }
+            else if (shift)
+            {
+                shift = false;
+                xshift = true;
+            }
+            else
+            {
+                shift = true;
+            }
             repeat = true;
         }
         consumed = true;
-#undef SHM
-#undef SHD
     }
     else if (shift && key == KEY_ENTER)
     {
@@ -5747,8 +5748,8 @@ bool user_interface::handle_functions(int key, object_p objp, bool user)
         alpha = false;
         lowercase = false;
     }
-    xshift = false;
     shift = false;
+    xshift = false;
 
     if (userOnce && usr == Settings.UserMode())
     {

--- a/src/user_interface.h
+++ b/src/user_interface.h
@@ -308,6 +308,7 @@ protected:
     bool     taLowercase  : 1;  // Lowercase transitory alpha
     bool     taPrevAlpha  : 1;  // Alpha mode before transitory alpha
     bool     taPrevLowerc : 1;  // Lowercase before transitory alpha
+    bool     delayedArrow : 1;  // Wait until key release for arrow key report
     bool     userOnce     : 1;  // User mode should be reset
     bool     shiftDrawn   : 1;  // Cache of drawn annunciators
     bool     xshiftDrawn  : 1;  // Cache


### PR DESCRIPTION
Add new variable `delayedArrow` to indicate we want the arrow keys reported after key release instead of relying on `last` key.

I generated a truth table for the shift state transformation black box and simplified the shift state change handling accordingly.

Reordered `shift` and `xshift` assignments to always set `shift` first (perhaps a bit OCD...).

Cleaned-up long press shift key handling to match my statements in commit 328733d3cdc7 (missed this one). Also set `repeat` in `xshift` state otherwise long press shift does only work in no shift or single shifted state.

Fixes #1041