### PR TITLE
src: corrected typo's in some builtin constants

### DIFF
--- a/src/constants.cc
+++ b/src/constants.cc
@@ -646,9 +646,9 @@ static const cstring basic_constants[] =
     "Size",     nullptr,
 
     // *Classical electron radius - Calculation from measurement
-    "re",       "[ 'CONVERT(Ⓒα²*Ⓒa0;1_fm)' "
-                "  'ROUND(Ⓡre*Ⓒre;-2)' "
-                "  'ROUND(3*Ⓢα/Ⓒα;-2)' "
+    "re",       "[ 'ROUND(CONVERT(Ⓒα^2*Ⓒa0; 1_fm); XPON(Ⓡre*Ⓒα^2*Ⓒa0) - XPON(Ⓒα^2*Ⓒa0) - 2)' "
+                "  'ROUND(Ⓡre*Ⓒre; -2)' "
+                "  'ROUND(3*Ⓢα/Ⓒα; -2)' "
                 "  2.818 fm ]",
     // *Proton charge radius - Measurement
     "rp",       "[ 8.4075⁳-16_m "

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -648,12 +648,13 @@ static const cstring basic_constants[] =
     // *Classical electron radius - Calculation from measurement
     "re",       "[ 'CONVERT(Ⓒα²*Ⓒa0;1_fm)' "
                 "  'ROUND(Ⓡre*Ⓒre;-2)' "
-                "  'ROUND(3*Ⓢα/α;-2)' "
+                "  'ROUND(3*Ⓢα/Ⓒα;-2)' "
                 "  2.818 fm ]",
     // *Proton charge radius - Measurement
-    "rp",       "[ 8.4075-16_m "
-                "  0.0064-16_m "
-                "  'ROUND(Ⓢrp/Ⓒrp;-2)' ]",
+    "rp",       "[ 8.4075⁳-16_m "
+                "  0.0064⁳-16_m "
+                "  'ROUND(Ⓢrp/Ⓒrp;-2)' "
+                "  0.841 fm ]",
     // *Bohr radius - Calculation from measurement
     "a0",       "[ 'ROUND(CONVERT(4*Ⓒπ*Ⓒε₀*Ⓒℏ²/(Ⓒme*Ⓒqe²);1_nm);XPON(UVAL(Ⓡa0*4*Ⓒπ*Ⓒε₀*Ⓒℏ²/(Ⓒme*Ⓒqe²)))-XPON(UVAL(4*Ⓒπ*Ⓒε₀*Ⓒℏ²/(Ⓒme*Ⓒqe²)))-2)' "
                 "  'CONVERT(ROUND(UBASE(Ⓢα/Ⓒα*Ⓒa0);-2);1_nm)' "
@@ -663,7 +664,7 @@ static const cstring basic_constants[] =
     "σe",       "[ 'ROUND(CONVERT(8*Ⓒπ*Ⓒre²/3;1_m²);XPON(UVAL(Ⓡσe*8*Ⓒπ*Ⓒre²/3))-XPON(UVAL(8*Ⓒπ*Ⓒre²/3))-2)' "
                 "  'CONVERT(ROUND(UBASE(Ⓡσe*Ⓒσe);-2);1_m²)' "
                 "  'ROUND(6*Ⓢα/Ⓒα;-2)' "
-                "  6.652⁳⁻²⁹ m↑2 ]",
+                "  6.652⁳⁻²⁹ m² ]",
 
 
     // ------------------------------------------------------------------------

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -11333,7 +11333,7 @@ void tests::constants_menu()
         .test(LSHIFT, F1).expect("2.81794 03204 6 fm");
     step("Proton charge radius")
         .test(CLEAR, NOSHIFT, F2).expect("rp")
-        .test(LSHIFT, F2).expect("8.4075");
+        .test(LSHIFT, F2).expect("8.4075⁳⁻¹⁶ m");
     step("Bohr radius")
         .test(CLEAR, NOSHIFT, F3).expect("a0")
         .test(LSHIFT, F3).expect("0.05291 77210 54 nm");


### PR DESCRIPTION
While investigating issue #1574
it appeared the definitions of re and rp contained errors. The definition of rp was missing its label.
The definition of σe had an incorrect unit in its label. Above errors are corrected.

Unfortunately this doesn't solve the issue.

Signed-off-by: Ed@vanGasteren.net