### PR TITLE
Fix "/bin/sh: 1: source: not found" when running `make wasm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,8 +542,8 @@ $(WASM_TARGET): $(OBJECTS) Makefile
 else
 
 $(WASM_TARGET): $(SOURCES) Makefile
-	(source emsdk/emsdk_env.sh && \
-	 make VARIANT=wasm PGM=js PGM_TARGET=wasm/$(TARGET).js SDK=sim )
+	(bash -cl "source emsdk/emsdk_env.sh && \
+	 make VARIANT=wasm PGM=js PGM_TARGET=wasm/$(TARGET).js SDK=sim")
 
 $(BUILD)/$(TARGET).elf: $(OBJECTS) Makefile
 	@tools/build_id -u


### PR DESCRIPTION
I got the following error on my machine (Linux Mint 22.1) after executing `make wasm`:

```shell
$ make wasm

(source emsdk/emsdk_env.sh && \
 make VARIANT=wasm PGM=js PGM_TARGET=wasm/db48x.js SDK=sim )
/bin/sh: 1: source: not found
make: *** [Makefile:546: wasm/db48x.js] Error 127
```
This happens because this `make` call inside a `Makefile`, does not use a bash shell (with he built-in source command) but a simple sh shell. The fix makes it explicit which shell to use.