### PR TITLE
Fix WebAssembly binary using 100% in one of the CPU cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ DECIMIZE = $(TOOLS)/decimize/decimize
 FLASH=$(BUILD)/$(TARGET)_flash.bin
 QSPI =$(BUILD)/$(TARGET)_qspi.bin
 
-#VERSION=$(shell git describe --dirty=Z --abbrev=4 | sed -e 's/^v//g' -e 's/-g/-/g' | cut -c 1-16)
-VERSION=jpcano
+VERSION=$(shell git describe --dirty=Z --abbrev=4 | sed -e 's/^v//g' -e 's/-g/-/g' | cut -c 1-16)
 VERSION_H=src/$(PLATFORM)/version.h
 
 

--- a/Makefile
+++ b/Makefile
@@ -436,7 +436,7 @@ LDFLAGS +=	-s MODULARIZE=0				\
 		-s RESERVED_FUNCTION_POINTERS=20	\
 		-s PTHREAD_POOL_SIZE=4			\
 		--bind -pthread \
-		-sASYNCIFY # Used to be able to sleep withing a webassembly context
+		-sASYNCIFY # Used to be able to sleep within a webassembly context
 
 #------------------------------------------------------------------------------
 else

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ DECIMIZE = $(TOOLS)/decimize/decimize
 FLASH=$(BUILD)/$(TARGET)_flash.bin
 QSPI =$(BUILD)/$(TARGET)_qspi.bin
 
-VERSION=$(shell git describe --dirty=Z --abbrev=4 | sed -e 's/^v//g' -e 's/-g/-/g' | cut -c 1-16)
+#VERSION=$(shell git describe --dirty=Z --abbrev=4 | sed -e 's/^v//g' -e 's/-g/-/g' | cut -c 1-16)
+VERSION=jpcano
 VERSION_H=src/$(PLATFORM)/version.h
 
 
@@ -435,7 +436,8 @@ CFLAGS += 	-O3 -pthread
 LDFLAGS +=	-s MODULARIZE=0				\
 		-s RESERVED_FUNCTION_POINTERS=20	\
 		-s PTHREAD_POOL_SIZE=4			\
-		--bind -pthread
+		--bind -pthread \
+		-sASYNCIFY # Used to be able to sleep withing a webassembly context
 
 #------------------------------------------------------------------------------
 else

--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -1459,7 +1459,7 @@ void ui_ms_sleep(uint ms_delay)
 //   Suspend the current thread for the given interval in milliseconds
 // ----------------------------------------------------------------------------
 {
-
+    emscripten_sleep(ms_delay);
 }
 
 

--- a/src/wasm/emcc.h
+++ b/src/wasm/emcc.h
@@ -1,4 +1,5 @@
 #include <emscripten/bind.h>
+#include <emscripten.h>
 using namespace emscripten;
 
 extern uintptr_t wasm_updated_screen;


### PR DESCRIPTION
I noticed that the WASM app (https://48calc.org/db48x/index.html) kept one of my CPU cores at 100%.
This is due to the fact that the app is not sleeping between keypress or display refresh (the sleep function is empty on WASM code).

This fix links the WASM code against [Asyncify](https://emscripten.org/docs/porting/asyncify.html) in order to transform the WASM code in a way that can be paused/resumed. There is a tradeoff after linking the code with this library, the wasm binary is almost 4x larger (~2MB vs ~7MB). In my opinion, even if the binary is larger, the fix is justified as the app now runs efficiently in the browser.