### PR TITLE
Fix several spelling/typos inside `/doc` and `/help` directories

### DIFF
--- a/doc/0-Overview.md
+++ b/doc/0-Overview.md
@@ -667,11 +667,11 @@ operate on these items when it makes sense. Therefore:
   produces a matrix with infinities. DB48X by default produces a `Divide by
   zero` error.
 
-* DB48X accept matrices and vectors as input to algebraic functions, and returns
+* DB48X accepts matrices and vectors as input to algebraic functions, and returns
   a matrix or vector with the function applied to all elements. For example,
   `[a b c] sin ` returns `[ 'sin a' 'sin b' 'sin c' ]`.
 
-* Similarly, DB48X accept operations between a constant and a vector or matrix.
+* Similarly, DB48X accepts operations between a constant and a vector or matrix.
   This applies the same binary operation to all components of the vector or
   matrix. `[ a b c ] x +` returns `[ 'a+x' 'b+x' 'c+x' ]`. Consistent with that
   logic, `inv` works on vectors, and inverts each component, so that
@@ -791,7 +791,7 @@ To navigate the help on the calculator, use the following keys:
   next link respectively. The keys _÷_ and _9_ also select the previous
   link, while the keys _×_ and _3_ can also be used to select the next link.
 
-* The _F6_ key correspond to the `←Menu` label, and returns one step back in
+* The _F6_ key corresponds to the `←Menu` label, and returns one step back in
   the help history. The _←_ key achieves the same effect.
 
 * To follow a highlighted link, click on the _ENTER_ key.

--- a/doc/0-Overview.md
+++ b/doc/0-Overview.md
@@ -57,7 +57,7 @@ RPL commands in the HP50G and in DB48X into
 The objective is to re-create an RPL-like experience, but to optimize it for the
 existing DM42 physical hardware.
 <!--- DM42 --->
-Ideally, DB48X should be fully usable without a keyboard overlay. though one is
+Ideally, DB48X should be fully usable without a keyboard overlay, though one is
 [being worked on](https://github.com/c3d/db48x/blob/stable/Keyboard-Layout.png).
 
 Compared to the original HP48, the DM42 has a much larger screen, but no

--- a/doc/1-introduction.md
+++ b/doc/1-introduction.md
@@ -64,8 +64,8 @@ DB48X keyboard overlay, this key is also marked as `=` for that reason.
 
 Since introducing the first scientific pocket calculator, the HP-35, in 1972,
 and with it the reverse polish notation (RPN), Hewlett-Packard perfected its
-line-up for decades. This led to such powerhouses pocket computers such as as
-the HP-41C series, or tiny wonders of pocket efficiency such as the HP-15C. Many
+line-up for decades. This led to such powerhouse pocket computers such as the
+HP-41C series, or tiny wonders of pocket efficiency such as the HP-15C. Many
 of these calculators, including the models we just cited, were capable of
 advanced mathematics, including dealing with complex numbers, matrix operations,
 root finding or numeric integration.

--- a/doc/2-Quickstart.md
+++ b/doc/2-Quickstart.md
@@ -1573,8 +1573,8 @@ program file.
 
 ### Installing the DB48X program file
 
-To install the program file file, [select the system menu](#system-menu) and
-then select the `Load program` menu entry.
+To install the program file, [select the system menu](#system-menu) and then
+select the `Load program` menu entry.
 
 After loading the DB48X program, the firmware loaded asks you to press a key,
 and the new firmware automatically runs.

--- a/doc/3-Types.md
+++ b/doc/3-Types.md
@@ -358,11 +358,11 @@ implements, and differ from the HP RPL implementation in the following ways:
 
 * In order to support the computer-related units better, also recognize the
   [power-of-two variants](https://en.wikipedia.org/wiki/Kilobyte),
-  e.g. `1_kiB` is `1024_B`. Also recogize the `K` prefix in addition to `k`.
+  e.g. `1_kiB` is `1024_B`. Also recognize the `K` prefix in addition to `k`.
 
 ### Units file
 
-The built-in units can be overriden by your own set of units, which is defined
+The built-in units can be overridden by your own set of units, which is defined
 in a CSV file called `config/units.csv` in the calculator. CSV stands for "Comma
 separated values, and is a common interchange format for spreadsheet data.
 
@@ -385,10 +385,10 @@ to convert between various monetary units:
 * Rows in a file containing a single value denote unit menus, unless the value
   begins with an `=` sign.
 
-* Rows in a file containing two ore more values denote unit menu entries, which
+* Rows in a file containing two or more values denote unit menu entries, which
   will be added to the previous menu.
 
-* The first column in these rows give the name of the unit as shown in the menu.
+* The first column in these rows gives the name of the unit as shown in the menu.
 
 * The second column in these rows gives the definition of the unit.
 
@@ -398,17 +398,17 @@ to convert between various monetary units:
   standard "kilo" unit prefix, and `h` is an existing unit.
 
 A unit where the value is `1` of the same unit is a base unit. This is the case
-for `USD` in the example above, which is considered the base units for monetary
+for `USD` in the example above, which is considered the base unit for monetary
 exchanges. Units that refer to the same base unit can be converted with one
 another. For example, you can convert between `GBP` and `AUD` because they both
 have the same `USD` base unit.
 
 The commands `ShowBuiltinUnits` and `HideBuiltinUnits` indicate if the built-in
-uits should be shown after the units loaded from the file. The default is that
+units should be shown after the units loaded from the file. The default is that
 when a units file is present, the built-in units are hidden. This only affects
 the menus. Built-in units can always be used in expressions if they are typed
 manually. However, units loaded from file will be looked up first, so that a
-built-in unit can be overriden by the units file, which can be useful if a
+built-in unit can be overridden by the units file, which can be useful if a
 definition changes like the US Survey foot changed on January 1st, 2023.
 
 If you build a units file, it is recommended that you do not exceed 17 unit

--- a/doc/3-Types.md
+++ b/doc/3-Types.md
@@ -175,7 +175,7 @@ numbers. For example, `0.2` cannot be represented exactly using a binary format.
 
 This command disables accelerated binary floating point, and ensures that the
 variable-precision decimal floating-point format is used even for `Precision`
-values below 16.. This setting is the opposite of `HardwareFloatingPoint`.
+values below 16. This setting is the opposite of `HardwareFloatingPoint`.
 
 
 ## Based numbers
@@ -532,7 +532,7 @@ If the `UndefinedValue` flag is set, such operations return the constant
 `?`, and further operations on the value will keep returning the same undefined
 result.
 
-If the `UndefinedValue` flag is is clear, which corresponds to `UndefinedError`
+If the `UndefinedValue` flag is clear, which corresponds to `UndefinedError`
 being set, such operations will generate an `Undefined operation` error.
 
 

--- a/doc/4-RPL-examples.md
+++ b/doc/4-RPL-examples.md
@@ -131,7 +131,7 @@ third method is often the easiest to write, read, and debug.
 
 ### Efficiency vs. readability
 
-Programmers should be be aware that the DB48x implementation of local variables
+Programmers should be aware that the DB48x implementation of local variables
 makes accessing them as efficient as accessing a stack value. Furthermore, using
 local variables often makes it possible to avoid stack manipulation commands.
 

--- a/doc/calc-help/equations.md
+++ b/doc/calc-help/equations.md
@@ -1665,7 +1665,7 @@ E₀=E
 
 #### Driven Damped Oscillations
 
-We are considering here a damped mass-spring oscillator where the external driving force is of the form `Fdriving = Fd*cos(ω*t)` acting at the angular frequency `ω`. The corresponding differential equation : `−k*x − b*dx/dt + Fd*cos(ω*t) = m*d^2x/dt^2` describes the driven damped oscillations. When the driving frequency `ω` comes close to the natural frequency `ω₀` this is the onset of resonance with amplitude increase and the total energy accumulates up to a possible catastrophy when the structure is overcome (see fig)
+We are considering here a damped mass-spring oscillator where the external driving force is of the form `Fdriving = Fd*cos(ω*t)` acting at the angular frequency `ω`. The corresponding differential equation : `−k*x − b*dx/dt + Fd*cos(ω*t) = m*d^2x/dt^2` describes the driven damped oscillations. When the driving frequency `ω` comes close to the natural frequency `ω₀` this is the onset of resonance with amplitude increase and the total energy accumulates up to a possible catastrophe when the structure is overcome (see fig)
 
 ![Driven Damped Oscillations](img/Driven Damped Oscillations2_BW.bmp)
 
@@ -2140,7 +2140,7 @@ Tair=-20_°C  u=2200_km/h
 
 #### String Standing Waves
 
-A string being fixed or free at its ends admits only discrete harmonics as standing waves on the string. A string being fixed (or free) at both ends admits all integer harmonics. A string being being fixed at one end and free at the other end admits only all odd integer harmonics.
+A string fixed or free at its ends admits only discrete harmonics as standing waves on the string. A string fixed (or free) at both ends admits all integer harmonics. A string fixed at one end and free at the other end admits only all odd integer harmonics.
 
 * To calculate `[v_m/s;k_(r/m);ω_(r/s);Ts_N;y_m;ffixedfixed_Hz;ffixedfree_Hz]` (Propagation speed of waves, Wave number; Angular frequency; Tension; Frequency of harmonics on a string fixed at both ends; Frequency of harmonics on a string fixed at one end and free at the other end) from 9 known variables:
 ```rpl
@@ -2151,7 +2151,7 @@ A string being fixed or free at its ends admits only discrete harmonics as stand
 
 #### Sound Wave Harmonics
 
-A tube being open or closed at its ends admits only discrete harmonics as standing waves of the sound in the air within the tube. A tube being open (or closed) at both ends admits all integer harmonics. A tube being being open at one end and closed at the other end admits only all odd integer harmonics.
+A tube open or closed at its ends admits only discrete harmonics as standing waves of the sound in the air within the tube. A tube open (or closed) at both ends admits all integer harmonics. A tube open at one end and closed at the other end admits only all odd integer harmonics.
 
 * To calculate `[v_m/s;k_(r/m);ω_(r/s);Tair_°C;s_m;fopenopen_Hz;fopenclose_Hz]` (Propagation speed of sound waves; Wave number; Angular frequency, Temperature; Frequency of harmonics in a tube open at both ends; Frequency of harmonics in a tube open at one end and close at the other end) from 8 known variables:
 ```rpl
@@ -2613,7 +2613,7 @@ The 43 variables in the Modern Physics section are :
 
 #### Planck & Wien Comparison
 
-In this section, two comparisons are done between the Planck and Wien spectral distributiona. Based on a incomplete thermodynamic argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distribution differs notably or agree. The asymptotic agreement for large frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding enissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, For the Planck distribution, one can choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
+In this section, two comparisons are done between the Planck and Wien spectral distributions. Based on an incomplete thermodynamic argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distributions differ notably or agree. The asymptotic agreement for large frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding emissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, for the Planck distribution, one can choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
 
 ![Planck & Wien Comparison](img/Planck_and_Wien_Distributions.bmp)
 
@@ -2626,7 +2626,7 @@ T=1273.15_K  A=100_cm^2  fa=7.48475 43283 5⁳¹³ Hz  fb=3.18337 69964�
 
 #### Planck & Rayleigh-Jeans Comparison
 
-In this section, two comparisons are done between the Planck and Rayleigh-Jeans spectral distributiona. Based on the equipartition theorem argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distribution agree or differs considerably, leading to a divergence called UV catastrophy corresponding to unphysical fractions greather than one. The asymptotic agreement for small frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding enissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, For the Planck distribution, one could choose any other values for `fa` & `fb` and computes the corresponding `FrPlab`, `ebfafb` and `q`.
+In this section, two comparisons are done between the Planck and Rayleigh-Jeans spectral distributions. Based on the equipartition theorem argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distributions agree or differ considerably, leading to a divergence called UV catastrophe corresponding to unphysical fractions greater than one. The asymptotic agreement for small frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding emissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, for the Planck distribution, one could choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
 
 ![Planck & Rayleigh-Jeans Comparison](img/Planck_and_Rayleigh-Jeans_Distributions.bmp)
 
@@ -2639,7 +2639,7 @@ T=1273.15_K  A=100_cm^2  fa=2.65281 41636 9⁳¹⁰ Hz  fb=7.48475 43283
 
 #### Photoelectric Effect
 
-Einstein explained the photoelectric effect with the energy quantification of the electromagnetic wave. The photoelectron is then emitted only if the energy `E` of the incident photon is greather or equal to the work function `φ` of the material. A simple energy budget equation determines the maximum kinetic energy `Kmax` of the photoelectron.
+Einstein explained the photoelectric effect with the energy quantification of the electromagnetic wave. The photoelectron is then emitted only if the energy `E` of the incident photon is greater or equal to the work function `φ` of the material. A simple energy budget equation determines the maximum kinetic energy `Kmax` of the photoelectron.
 
 * To calculate `[f_THz;Eph_eV;f0_THz;λ0_nm;Kmax_eV;Vo_V;vmax_m/s]` (Frequency, Photon energy; Threshold frequency; Threshold wavelength; Maximum kinetic energy of photoelectron; Stoping potential; Maximum speed of photoelectron) from 2 known variables:
 ```rpl

--- a/doc/commands/dirs.md
+++ b/doc/commands/dirs.md
@@ -47,7 +47,7 @@ The format of the file depends on how the name ends:
 
 * `.48b`: the value is stored in version-specific binary format. This format is only guaranteed to be readable by the same firmware version that wrote it, but it is more compact, faster and energy efficient than the source format.
 
-* `.csv`: The value is stored in comma-separated values format. This is mostly interesting for arrays and lists, which can be echanged with spreadsheets and other PC applications that can input or output CSV files.
+* `.csv`: The value is stored in comma-separated values format. This is mostly interesting for arrays and lists, which can be exchanged with spreadsheets and other PC applications that can input or output CSV files.
 
 
 ## STO+

--- a/doc/commands/finance.md
+++ b/doc/commands/finance.md
@@ -18,7 +18,7 @@ TVM
 
 ## FinanceRounding
 
-This setting defines the number of digits values returned by finance values will be rounded two. The default avalue is `2`.
+This setting defines how many digits finance values are rounded to. The default value is `2`.
 
 ```rpl
 @ Set finance rounding to 10 digits

--- a/doc/commands/library.md
+++ b/doc/commands/library.md
@@ -1,12 +1,12 @@
 # Library Management
 
-DB48x features a [library](#library) that can contain arbitary RPL code,
+DB48x features a [library](#library) that can contain arbitrary RPL code,
 which is made readily available for use in your programs.
 
 References to library functions are efficient both in terms of memory usage and
 execution speed.  Typically, a reference to a library item takes 2 or 3 bytes,
 and evaluating it is as fast as if it was on the stack, and faster than if
-storedin a global variable.
+stored in a global variable.
 
 Library items are also shared across DB48x states.
 
@@ -14,13 +14,13 @@ A key aspect of the execution speed for library items is that they are loaded
 from disk only once, and then cached in compiled form in memory. This is how the
 next uses of that library item can be as fast as if it was on the stack.
 
- Library items that are currently loaded in memory can be identified using
-`Libs`. The `Attach` commadn can be used to load items ahead of time. The
+Library items that are currently loaded in memory can be identified using
+`Libs`. The `Attach` command can be used to load items ahead of time. The
 `Detach` command can be used to evacuate library elements that are no longer
 used.
 
 When you modify the content of the library, you can use the following sequence
-to make sure that the new version of thelibrary items are reloaded from disk:
+to make sure that the new version of the library items are reloaded from disk:
 
 ```rpl
 LIBS DUP DETACH ATTACH

--- a/doc/commands/solvers.md
+++ b/doc/commands/solvers.md
@@ -46,7 +46,7 @@ If equations can be solved one at a time, then the `Root` command will use the
 multiple equation solver to solve them in turn.
 
 For example, in the following code, the multiple equation solver can first solve
-for `y` using the second equation, the solve for `x`. In both cases, it can use
+for `y` using the second equation, then solve for `x`. In both cases, it can use
 the `Isolate` command to get an exact expression for the solution.
 
 ```rpl
@@ -58,7 +58,7 @@ the `Isolate` command to get an exact expression for the solution.
 
 If equations cannot be solved one at a time, then the `Root` command will
 compute the Jacobian of the equations given as input, and use that to solve the
-systerm iteratively. This is necessary when there is "crosstalk" between
+system iteratively. This is necessary when there is "crosstalk" between
 variables across equations.
 
 For example, to find the coordinates of the intersection between two circles,

--- a/doc/commands/system.md
+++ b/doc/commands/system.md
@@ -313,7 +313,7 @@ power, because of additional animations or more expensive graphical rendering.
 ## Bytes
 
 Return the size of the object and a hash of its value. On classic RPL systems,
-teh hash is a 5-nibbles CRC32. On DB48X, the hash is a based integer of the
+the hash is a 5-nibbles CRC32. On DB48X, the hash is an integer based on the
 current [wordsize](#stws) corresponding to the binary representation of the
 object.
 
@@ -327,7 +327,7 @@ value of the integer, and `xx` represents the integer type, as returned by the
 ## Type
 
 Return the type of the object as a numerical value. The value is not guaranteed
-to be portable across versions of DB48X (and pretty much is guarantteed to _not_
+to be portable across versions of DB48X (and pretty much is guaranteed to _not_
 be portable at the current stage of development).
 
 ### HP-compatible types

--- a/doc/commands/ui.md
+++ b/doc/commands/ui.md
@@ -85,7 +85,7 @@ the command line, or a list containing up to three elements:
 * The object defining the initial content of the command line
 * A cursor position on the command line, the index starting at 1, where 0 is the
   end of the command-line; or a list or array containing the row and column,
-  starting at 1, where 0 indicates the end of of the row or the last column.
+  starting at 1, where 0 indicates the end of the row or the last column.
 * A validation object
 
 The validation object indicates how the input is validated. If the validation
@@ -95,7 +95,7 @@ case-insensitive):
 * `α`, `alpha` or `text` selects text mode and enable alpha mode. The
   value is retured as text.
 * `alg`, `algebraic` or `expression` selects algebraic mode, which can be used
-  to to enter an expression. The value is returned as text for `alg` (for
+  to enter an expression. The value is returned as text for `alg` (for
   compatibility with HP), as an algebraic value (including numbers) if
   `algebraic` is used, as an expression object for `expression` is used.
 * `value` or `object` checks that the command line describes a single valid RPL

--- a/doc/commands/ui.md
+++ b/doc/commands/ui.md
@@ -93,7 +93,7 @@ object is a text or symbol, it can be one of the following (the comparison being
 case-insensitive):
 
 * `α`, `alpha` or `text` selects text mode and enable alpha mode. The
-  value is retured as text.
+  value is returned as text.
 * `alg`, `algebraic` or `expression` selects algebraic mode, which can be used
   to enter an expression. The value is returned as text for `alg` (for
   compatibility with HP), as an algebraic value (including numbers) if

--- a/doc/commands/user-mode.md
+++ b/doc/commands/user-mode.md
@@ -13,14 +13,14 @@ When `UserModeLock` is selected, each use toggles user mode on or off.
 ## KeyMap
 
 Key assignments on DB48x are not global, unlike what happens with `ASN` on HP
-claculators. Instead, assignments are stored in a special variable (really a
+calculators. Instead, assignments are stored in a special variable (really a
 directory containing numbered variables) called `KeyMap`. This approach makes it
 possible to have per-directory key assignments, and to use normal tools such as
 `Store` and `Recall` to manipulate key assignments.
 
 If a `KeyMap` is present in the current directory, it overrides assignments
 while you are in that directory. However, key assignments from the enclosing
-directories are still considered when they are not overriden. In other words,
+directories are still considered when they are not overridden. In other words,
 key assignments are a hierarchy. When no key assignment is found in any of the
 `KeyMap` variables in any of the enclosing directories, then the default key
 binding for that key applies.

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -2982,11 +2982,11 @@ implements, and differ from the HP RPL implementation in the following ways:
 
 * In order to support the computer-related units better, also recognize the
   [power-of-two variants](https://en.wikipedia.org/wiki/Kilobyte),
-  e.g. `1_kiB` is `1024_B`. Also recogize the `K` prefix in addition to `k`.
+  e.g. `1_kiB` is `1024_B`. Also recognize the `K` prefix in addition to `k`.
 
 ### Units file
 
-The built-in units can be overriden by your own set of units, which is defined
+The built-in units can be overridden by your own set of units, which is defined
 in a CSV file called `config/units.csv` in the calculator. CSV stands for "Comma
 separated values, and is a common interchange format for spreadsheet data.
 
@@ -3009,7 +3009,7 @@ to convert between various monetary units:
 * Rows in a file containing a single value denote unit menus, unless the value
   begins with an `=` sign.
 
-* Rows in a file containing two ore more values denote unit menu entries, which
+* Rows in a file containing two or more values denote unit menu entries, which
   will be added to the previous menu.
 
 * The first column in these rows give the name of the unit as shown in the menu.
@@ -3028,11 +3028,11 @@ another. For example, you can convert between `GBP` and `AUD` because they both
 have the same `USD` base unit.
 
 The commands `ShowBuiltinUnits` and `HideBuiltinUnits` indicate if the built-in
-uits should be shown after the units loaded from the file. The default is that
+units should be shown after the units loaded from the file. The default is that
 when a units file is present, the built-in units are hidden. This only affects
 the menus. Built-in units can always be used in expressions if they are typed
 manually. However, units loaded from file will be looked up first, so that a
-built-in unit can be overriden by the units file, which can be useful if a
+built-in unit can be overridden by the units file, which can be useful if a
 definition changes like the US Survey foot changed on January 1st, 2023.
 
 If you build a units file, it is recommended that you do not exceed 17 unit
@@ -12262,13 +12262,13 @@ calculator operations.
 ```
 # Library Management
 
-DB48x features a [library](#library) that can contain arbitary RPL code,
+DB48x features a [library](#library) that can contain arbitrary RPL code,
 which is made readily available for use in your programs.
 
 References to library functions are efficient both in terms of memory usage and
 execution speed.  Typically, a reference to a library item takes 2 or 3 bytes,
 and evaluating it is as fast as if it was on the stack, and faster than if
-storedin a global variable.
+stored in a global variable.
 
 Library items are also shared across DB48x states.
 
@@ -12276,13 +12276,13 @@ A key aspect of the execution speed for library items is that they are loaded
 from disk only once, and then cached in compiled form in memory. This is how the
 next uses of that library item can be as fast as if it was on the stack.
 
- Library items that are currently loaded in memory can be identified using
-`Libs`. The `Attach` commadn can be used to load items ahead of time. The
+Library items that are currently loaded in memory can be identified using
+`Libs`. The `Attach` command can be used to load items ahead of time. The
 `Detach` command can be used to evacuate library elements that are no longer
 used.
 
 When you modify the content of the library, you can use the following sequence
-to make sure that the new version of thelibrary items are reloaded from disk:
+to make sure that the new version of the library items are reloaded from disk:
 
 ```rpl
 LIBS DUP DETACH ATTACH
@@ -16237,7 +16237,7 @@ power, because of additional animations or more expensive graphical rendering.
 ## Bytes
 
 Return the size of the object and a hash of its value. On classic RPL systems,
-teh hash is a 5-nibbles CRC32. On DB48X, the hash is a based integer of the
+the hash is a 5-nibbles CRC32. On DB48X, the hash is an integer based on the
 current [wordsize](#stws) corresponding to the binary representation of the
 object.
 
@@ -16251,7 +16251,7 @@ value of the integer, and `xx` represents the integer type, as returned by the
 ## Type
 
 Return the type of the object as a numerical value. The value is not guaranteed
-to be portable across versions of DB48X (and pretty much is guarantteed to _not_
+to be portable across versions of DB48X (and pretty much is guaranteed to _not_
 be portable at the current stage of development).
 
 ### HP-compatible types
@@ -17178,14 +17178,14 @@ When `UserModeLock` is selected, each use toggles user mode on or off.
 ## KeyMap
 
 Key assignments on DB48x are not global, unlike what happens with `ASN` on HP
-claculators. Instead, assignments are stored in a special variable (really a
+calculators. Instead, assignments are stored in a special variable (really a
 directory containing numbered variables) called `KeyMap`. This approach makes it
 possible to have per-directory key assignments, and to use normal tools such as
 `Store` and `Recall` to manipulate key assignments.
 
 If a `KeyMap` is present in the current directory, it overrides assignments
 while you are in that directory. However, key assignments from the enclosing
-directories are still considered when they are not overriden. In other words,
+directories are still considered when they are not overridden. In other words,
 key assignments are a hierarchy. When no key assignment is found in any of the
 `KeyMap` variables in any of the enclosing directories, then the default key
 binding for that key applies.

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -996,8 +996,8 @@ DB48X keyboard overlay, this key is also marked as `=` for that reason.
 
 Since introducing the first scientific pocket calculator, the HP-35, in 1972,
 and with it the reverse polish notation (RPN), Hewlett-Packard perfected its
-line-up for decades. This led to such powerhouses pocket computers such as as
-the HP-41C series, or tiny wonders of pocket efficiency such as the HP-15C. Many
+line-up for decades. This led to such powerhouse pocket computers such as the
+HP-41C series, or tiny wonders of pocket efficiency such as the HP-15C. Many
 of these calculators, including the models we just cited, were capable of
 advanced mathematics, including dealing with complex numbers, matrix operations,
 root finding or numeric integration.
@@ -2589,8 +2589,8 @@ program file.
 
 ### Installing the DB48X program file
 
-To install the program file file, [select the system menu](#system-menu) and
-then select the `Load program` menu entry.
+To install the program file, [select the system menu](#system-menu) and then
+select the `Load program` menu entry.
 
 After loading the DB48X program, the firmware loaded asks you to press a key,
 and the new firmware automatically runs.
@@ -2799,7 +2799,7 @@ numbers. For example, `0.2` cannot be represented exactly using a binary format.
 
 This command disables accelerated binary floating point, and ensures that the
 variable-precision decimal floating-point format is used even for `Precision`
-values below 16.. This setting is the opposite of `HardwareFloatingPoint`.
+values below 16. This setting is the opposite of `HardwareFloatingPoint`.
 
 
 ## Based numbers
@@ -3156,7 +3156,7 @@ If the `UndefinedValue` flag is set, such operations return the constant
 `?`, and further operations on the value will keep returning the same undefined
 result.
 
-If the `UndefinedValue` flag is is clear, which corresponds to `UndefinedError`
+If the `UndefinedValue` flag is clear, which corresponds to `UndefinedError`
 being set, such operations will generate an `Undefined operation` error.
 
 
@@ -3315,7 +3315,7 @@ third method is often the easiest to write, read, and debug.
 
 ### Efficiency vs. readability
 
-Programmers should be be aware that the DB48x implementation of local variables
+Programmers should be aware that the DB48x implementation of local variables
 makes accessing them as efficient as accessing a stack value. Furthermore, using
 local variables often makes it possible to avoid stack manipulation commands.
 
@@ -3577,14 +3577,14 @@ For example, if the stack contains `10` in level 3, `6` in level 2 and `20` in
 level 1, then:
 
 * `→ a « a a ^ »` or `→ a 'a^a'` will execute with `a` containing `20`, and then
-  compute evaluate `20^20`, i.e. `104 857 600 000 000 000 000 000 000`.
+  compute `20^20`, i.e. `104 857 600 000 000 000 000 000 000`.
 
 * `→ a b « a b ^ »` or `→ a b 'a^b'` will execute with `a` containing `6`, and
-  `b` containing `20`, then compute evaluate `6^20`, i.e.
+  `b` containing `20`, then compute `6^20`, i.e.
   `3 656 158 440 062 976`.
 
 * `→ a b c « a b ^ c + »` or `→ a b c 'a^b+c'` will execute with `a` containing
-  `10`, `b` containing `6` and `c` containing `20`, then compute evaluate
+  `10`, `b` containing `6` and `c` containing `20`, then compute
   `10^6+20`, i.e.  `1 000 020`.
 
 ### Advantages of Local Variables
@@ -8455,7 +8455,7 @@ E₀=E
 
 #### Driven Damped Oscillations
 
-We are considering here a damped mass-spring oscillator where the external driving force is of the form `Fdriving = Fd*cos(ω*t)` acting at the angular frequency `ω`. The corresponding differential equation : `−k*x − b*dx/dt + Fd*cos(ω*t) = m*d^2x/dt^2` describes the driven damped oscillations. When the driving frequency `ω` comes close to the natural frequency `ω₀` this is the onset of resonance with amplitude increase and the total energy accumulates up to a possible catastrophy when the structure is overcome (see fig)
+We are considering here a damped mass-spring oscillator where the external driving force is of the form `Fdriving = Fd*cos(ω*t)` acting at the angular frequency `ω`. The corresponding differential equation : `−k*x − b*dx/dt + Fd*cos(ω*t) = m*d^2x/dt^2` describes the driven damped oscillations. When the driving frequency `ω` comes close to the natural frequency `ω₀` this is the onset of resonance with amplitude increase and the total energy accumulates up to a possible catastrophe when the structure is overcome (see fig)
 
 ![Driven Damped Oscillations](img/Driven Damped Oscillations2_BW.bmp)
 
@@ -8930,7 +8930,7 @@ Tair=-20_°C  u=2200_km/h
 
 #### String Standing Waves
 
-A string being fixed or free at its ends admits only discrete harmonics as standing waves on the string. A string being fixed (or free) at both ends admits all integer harmonics. A string being being fixed at one end and free at the other end admits only all odd integer harmonics.
+A string fixed or free at its ends admits only discrete harmonics as standing waves on the string. A string fixed (or free) at both ends admits all integer harmonics. A string fixed at one end and free at the other end admits only all odd integer harmonics.
 
 * To calculate `[v_m/s;k_(r/m);ω_(r/s);Ts_N;y_m;ffixedfixed_Hz;ffixedfree_Hz]` (Propagation speed of waves, Wave number; Angular frequency; Tension; Frequency of harmonics on a string fixed at both ends; Frequency of harmonics on a string fixed at one end and free at the other end) from 9 known variables:
 ```rpl
@@ -8941,7 +8941,7 @@ A string being fixed or free at its ends admits only discrete harmonics as stand
 
 #### Sound Wave Harmonics
 
-A tube being open or closed at its ends admits only discrete harmonics as standing waves of the sound in the air within the tube. A tube being open (or closed) at both ends admits all integer harmonics. A tube being being open at one end and closed at the other end admits only all odd integer harmonics.
+A tube open or closed at its ends admits only discrete harmonics as standing waves of the sound in the air within the tube. A tube open (or closed) at both ends admits all integer harmonics. A tube open at one end and closed at the other end admits only all odd integer harmonics.
 
 * To calculate `[v_m/s;k_(r/m);ω_(r/s);Tair_°C;s_m;fopenopen_Hz;fopenclose_Hz]` (Propagation speed of sound waves; Wave number; Angular frequency, Temperature; Frequency of harmonics in a tube open at both ends; Frequency of harmonics in a tube open at one end and close at the other end) from 8 known variables:
 ```rpl
@@ -9403,7 +9403,7 @@ The 43 variables in the Modern Physics section are :
 
 #### Planck & Wien Comparison
 
-In this section, two comparisons are done between the Planck and Wien spectral distributiona. Based on a incomplete thermodynamic argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distribution differs notably or agree. The asymptotic agreement for large frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding enissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, For the Planck distribution, one can choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
+In this section, two comparisons are done between the Planck and Wien spectral distributions. Based on an incomplete thermodynamic argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distributions differ notably or agree. The asymptotic agreement for large frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding emissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, for the Planck distribution, one can choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
 
 ![Planck & Wien Comparison](img/Planck_and_Wien_Distributions.bmp)
 
@@ -9416,7 +9416,7 @@ T=1273.15_K  A=100_cm^2  fa=7.48475 43283 5⁳¹³ Hz  fb=3.18337 69964�
 
 #### Planck & Rayleigh-Jeans Comparison
 
-In this section, two comparisons are done between the Planck and Rayleigh-Jeans spectral distributiona. Based on the equipartition theorem argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distribution agree or differs considerably, leading to a divergence called UV catastrophy corresponding to unphysical fractions greather than one. The asymptotic agreement for small frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding enissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, For the Planck distribution, one could choose any other values for `fa` & `fb` and computes the corresponding `FrPlab`, `ebfafb` and `q`.
+In this section, two comparisons are done between the Planck and Rayleigh-Jeans spectral distributions. Based on the equipartition theorem argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distributions agree or differ considerably, leading to a divergence called UV catastrophe corresponding to unphysical fractions greater than one. The asymptotic agreement for small frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding emissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, for the Planck distribution, one could choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
 
 ![Planck & Rayleigh-Jeans Comparison](img/Planck_and_Rayleigh-Jeans_Distributions.bmp)
 
@@ -9429,7 +9429,7 @@ T=1273.15_K  A=100_cm^2  fa=2.65281 41636 9⁳¹⁰ Hz  fb=7.48475 43283
 
 #### Photoelectric Effect
 
-Einstein explained the photoelectric effect with the energy quantification of the electromagnetic wave. The photoelectron is then emitted only if the energy `E` of the incident photon is greather or equal to the work function `φ` of the material. A simple energy budget equation determines the maximum kinetic energy `Kmax` of the photoelectron.
+Einstein explained the photoelectric effect with the energy quantification of the electromagnetic wave. The photoelectron is then emitted only if the energy `E` of the incident photon is greater or equal to the work function `φ` of the material. A simple energy budget equation determines the maximum kinetic energy `Kmax` of the photoelectron.
 
 * To calculate `[f_THz;Eph_eV;f0_THz;λ0_nm;Kmax_eV;Vo_V;vmax_m/s]` (Frequency, Photon energy; Threshold frequency; Threshold wavelength; Maximum kinetic energy of photoelectron; Stoping potential; Maximum speed of photoelectron) from 2 known variables:
 ```rpl
@@ -14957,7 +14957,7 @@ If equations can be solved one at a time, then the `Root` command will use the
 multiple equation solver to solve them in turn.
 
 For example, in the following code, the multiple equation solver can first solve
-for `y` using the second equation, the solve for `x`. In both cases, it can use
+for `y` using the second equation, then solve for `x`. In both cases, it can use
 the `Isolate` command to get an exact expression for the solution.
 
 ```rpl
@@ -14969,7 +14969,7 @@ the `Isolate` command to get an exact expression for the solution.
 
 If equations cannot be solved one at a time, then the `Root` command will
 compute the Jacobian of the equations given as input, and use that to solve the
-systerm iteratively. This is necessary when there is "crosstalk" between
+system iteratively. This is necessary when there is "crosstalk" between
 variables across equations.
 
 For example, to find the coordinates of the intersection between two circles,
@@ -16945,7 +16945,7 @@ the command line, or a list containing up to three elements:
 * The object defining the initial content of the command line
 * A cursor position on the command line, the index starting at 1, where 0 is the
   end of the command-line; or a list or array containing the row and column,
-  starting at 1, where 0 indicates the end of of the row or the last column.
+  starting at 1, where 0 indicates the end of the row or the last column.
 * A validation object
 
 The validation object indicates how the input is validated. If the validation
@@ -16955,7 +16955,7 @@ case-insensitive):
 * `α`, `alpha` or `text` selects text mode and enable alpha mode. The
   value is retured as text.
 * `alg`, `algebraic` or `expression` selects algebraic mode, which can be used
-  to to enter an expression. The value is returned as text for `alg` (for
+  to enter an expression. The value is returned as text for `alg` (for
   compatibility with HP), as an algebraic value (including numbers) if
   `algebraic` is used, as an expression object for `expression` is used.
 * `value` or `object` checks that the command line describes a single valid RPL

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -609,11 +609,11 @@ operate on these items when it makes sense. Therefore:
   produces a matrix with infinities. DB48X by default produces a `Divide by
   zero` error.
 
-* DB48X accept matrices and vectors as input to algebraic functions, and returns
+* DB48X accepts matrices and vectors as input to algebraic functions, and returns
   a matrix or vector with the function applied to all elements. For example,
   `[a b c] sin ` returns `[ 'sin a' 'sin b' 'sin c' ]`.
 
-* Similarly, DB48X accept operations between a constant and a vector or matrix.
+* Similarly, DB48X accepts operations between a constant and a vector or matrix.
   This applies the same binary operation to all components of the vector or
   matrix. `[ a b c ] x +` returns `[ 'a+x' 'b+x' 'c+x' ]`. Consistent with that
   logic, `inv` works on vectors, and inverts each component, so that
@@ -733,7 +733,7 @@ To navigate the help on the calculator, use the following keys:
   next link respectively. The keys _÷_ and _9_ also select the previous
   link, while the keys _×_ and _3_ can also be used to select the next link.
 
-* The _F6_ key correspond to the `←Menu` label, and returns one step back in
+* The _F6_ key corresponds to the `←Menu` label, and returns one step back in
   the help history. The _←_ key achieves the same effect.
 
 * To follow a highlighted link, click on the _ENTER_ key.
@@ -11344,7 +11344,7 @@ TVM
 
 ## FinanceRounding
 
-This setting defines the number of digits values returned by finance values will be rounded two. The default avalue is `2`.
+This setting defines how many digits finance values are rounded to. The default value is `2`.
 
 ```rpl
 @ Set finance rounding to 10 digits
@@ -16953,7 +16953,7 @@ object is a text or symbol, it can be one of the following (the comparison being
 case-insensitive):
 
 * `α`, `alpha` or `text` selects text mode and enable alpha mode. The
-  value is retured as text.
+  value is returned as text.
 * `alg`, `algebraic` or `expression` selects algebraic mode, which can be used
   to enter an expression. The value is returned as text for `alg` (for
   compatibility with HP), as an algebraic value (including numbers) if

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -56,7 +56,7 @@ RPL commands in the HP50G and in DB48X into
 
 The objective is to re-create an RPL-like experience, but to optimize it for the
 existing DM42 physical hardware.
-Ideally, DB48X should be fully usable without a keyboard overlay. though one is
+Ideally, DB48X should be fully usable without a keyboard overlay, though one is
 [being worked on](https://github.com/c3d/db48x/blob/stable/Keyboard-Layout.png).
 
 Compared to the original HP48, the DM42 has a much larger screen, but no
@@ -10986,7 +10986,7 @@ The format of the file depends on how the name ends:
 
 * `.48b`: the value is stored in version-specific binary format. This format is only guaranteed to be readable by the same firmware version that wrote it, but it is more compact, faster and energy efficient than the source format.
 
-* `.csv`: The value is stored in comma-separated values format. This is mostly interesting for arrays and lists, which can be echanged with spreadsheets and other PC applications that can input or output CSV files.
+* `.csv`: The value is stored in comma-separated values format. This is mostly interesting for arrays and lists, which can be exchanged with spreadsheets and other PC applications that can input or output CSV files.
 
 
 ## STO+

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -618,11 +618,11 @@ operate on these items when it makes sense. Therefore:
   produces a matrix with infinities. DB50X by default produces a `Divide by
   zero` error.
 
-* DB50X accept matrices and vectors as input to algebraic functions, and returns
+* DB50X accepts matrices and vectors as input to algebraic functions, and returns
   a matrix or vector with the function applied to all elements. For example,
   `[a b c] sin ` returns `[ 'sin a' 'sin b' 'sin c' ]`.
 
-* Similarly, DB50X accept operations between a constant and a vector or matrix.
+* Similarly, DB50X accepts operations between a constant and a vector or matrix.
   This applies the same binary operation to all components of the vector or
   matrix. `[ a b c ] x +` returns `[ 'a+x' 'b+x' 'c+x' ]`. Consistent with that
   logic, `inv` works on vectors, and inverts each component, so that
@@ -742,7 +742,7 @@ To navigate the help on the calculator, use the following keys:
   next link respectively. The keys _÷_ and _9_ also select the previous
   link, while the keys _×_ and _3_ can also be used to select the next link.
 
-* The _F6_ key correspond to the `←Menu` label, and returns one step back in
+* The _F6_ key corresponds to the `←Menu` label, and returns one step back in
   the help history. The _←_ key achieves the same effect.
 
 * To follow a highlighted link, click on the _ENTER_ key.
@@ -11353,7 +11353,7 @@ TVM
 
 ## FinanceRounding
 
-This setting defines the number of digits values returned by finance values will be rounded two. The default avalue is `2`.
+This setting defines how many digits finance values are rounded to. The default value is `2`.
 
 ```rpl
 @ Set finance rounding to 10 digits
@@ -16970,7 +16970,7 @@ object is a text or symbol, it can be one of the following (the comparison being
 case-insensitive):
 
 * `α`, `alpha` or `text` selects text mode and enable alpha mode. The
-  value is retured as text.
+  value is returned as text.
 * `alg`, `algebraic` or `expression` selects algebraic mode, which can be used
   to enter an expression. The value is returned as text for `alg` (for
   compatibility with HP), as an algebraic value (including numbers) if

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -10995,7 +10995,7 @@ The format of the file depends on how the name ends:
 
 * `.48b`: the value is stored in version-specific binary format. This format is only guaranteed to be readable by the same firmware version that wrote it, but it is more compact, faster and energy efficient than the source format.
 
-* `.csv`: The value is stored in comma-separated values format. This is mostly interesting for arrays and lists, which can be echanged with spreadsheets and other PC applications that can input or output CSV files.
+* `.csv`: The value is stored in comma-separated values format. This is mostly interesting for arrays and lists, which can be exchanged with spreadsheets and other PC applications that can input or output CSV files.
 
 
 ## STO+

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -1005,8 +1005,8 @@ DB50X keyboard overlay, this key is also marked as `=` for that reason.
 
 Since introducing the first scientific pocket calculator, the HP-35, in 1972,
 and with it the reverse polish notation (RPN), Hewlett-Packard perfected its
-line-up for decades. This led to such powerhouses pocket computers such as as
-the HP-41C series, or tiny wonders of pocket efficiency such as the HP-15C. Many
+line-up for decades. This led to such powerhouse pocket computers such as the
+HP-41C series, or tiny wonders of pocket efficiency such as the HP-15C. Many
 of these calculators, including the models we just cited, were capable of
 advanced mathematics, including dealing with complex numbers, matrix operations,
 root finding or numeric integration.
@@ -2598,8 +2598,8 @@ program file.
 
 ### Installing the DB50X program file
 
-To install the program file file, [select the system menu](#system-menu) and
-then select the `Load program` menu entry.
+To install the program file, [select the system menu](#system-menu) and then
+select the `Load program` menu entry.
 
 After loading the DB50X program, the firmware loaded asks you to press a key,
 and the new firmware automatically runs.
@@ -2808,7 +2808,7 @@ numbers. For example, `0.2` cannot be represented exactly using a binary format.
 
 This command disables accelerated binary floating point, and ensures that the
 variable-precision decimal floating-point format is used even for `Precision`
-values below 16.. This setting is the opposite of `HardwareFloatingPoint`.
+values below 16. This setting is the opposite of `HardwareFloatingPoint`.
 
 
 ## Based numbers
@@ -3165,7 +3165,7 @@ If the `UndefinedValue` flag is set, such operations return the constant
 `?`, and further operations on the value will keep returning the same undefined
 result.
 
-If the `UndefinedValue` flag is is clear, which corresponds to `UndefinedError`
+If the `UndefinedValue` flag is clear, which corresponds to `UndefinedError`
 being set, such operations will generate an `Undefined operation` error.
 
 
@@ -3324,7 +3324,7 @@ third method is often the easiest to write, read, and debug.
 
 ### Efficiency vs. readability
 
-Programmers should be be aware that the DB48x implementation of local variables
+Programmers should be aware that the DB48x implementation of local variables
 makes accessing them as efficient as accessing a stack value. Furthermore, using
 local variables often makes it possible to avoid stack manipulation commands.
 
@@ -3586,14 +3586,14 @@ For example, if the stack contains `10` in level 3, `6` in level 2 and `20` in
 level 1, then:
 
 * `→ a « a a ^ »` or `→ a 'a^a'` will execute with `a` containing `20`, and then
-  compute evaluate `20^20`, i.e. `104 857 600 000 000 000 000 000 000`.
+  compute `20^20`, i.e. `104 857 600 000 000 000 000 000 000`.
 
 * `→ a b « a b ^ »` or `→ a b 'a^b'` will execute with `a` containing `6`, and
-  `b` containing `20`, then compute evaluate `6^20`, i.e.
+  `b` containing `20`, then compute `6^20`, i.e.
   `3 656 158 440 062 976`.
 
 * `→ a b c « a b ^ c + »` or `→ a b c 'a^b+c'` will execute with `a` containing
-  `10`, `b` containing `6` and `c` containing `20`, then compute evaluate
+  `10`, `b` containing `6` and `c` containing `20`, then compute
   `10^6+20`, i.e.  `1 000 020`.
 
 ### Advantages of Local Variables
@@ -8464,7 +8464,7 @@ E₀=E
 
 #### Driven Damped Oscillations
 
-We are considering here a damped mass-spring oscillator where the external driving force is of the form `Fdriving = Fd*cos(ω*t)` acting at the angular frequency `ω`. The corresponding differential equation : `−k*x − b*dx/dt + Fd*cos(ω*t) = m*d^2x/dt^2` describes the driven damped oscillations. When the driving frequency `ω` comes close to the natural frequency `ω₀` this is the onset of resonance with amplitude increase and the total energy accumulates up to a possible catastrophy when the structure is overcome (see fig)
+We are considering here a damped mass-spring oscillator where the external driving force is of the form `Fdriving = Fd*cos(ω*t)` acting at the angular frequency `ω`. The corresponding differential equation : `−k*x − b*dx/dt + Fd*cos(ω*t) = m*d^2x/dt^2` describes the driven damped oscillations. When the driving frequency `ω` comes close to the natural frequency `ω₀` this is the onset of resonance with amplitude increase and the total energy accumulates up to a possible catastrophe when the structure is overcome (see fig)
 
 ![Driven Damped Oscillations](img/Driven Damped Oscillations2_BW.bmp)
 
@@ -8939,7 +8939,7 @@ Tair=-20_°C  u=2200_km/h
 
 #### String Standing Waves
 
-A string being fixed or free at its ends admits only discrete harmonics as standing waves on the string. A string being fixed (or free) at both ends admits all integer harmonics. A string being being fixed at one end and free at the other end admits only all odd integer harmonics.
+A string fixed or free at its ends admits only discrete harmonics as standing waves on the string. A string fixed (or free) at both ends admits all integer harmonics. A string fixed at one end and free at the other end admits only all odd integer harmonics.
 
 * To calculate `[v_m/s;k_(r/m);ω_(r/s);Ts_N;y_m;ffixedfixed_Hz;ffixedfree_Hz]` (Propagation speed of waves, Wave number; Angular frequency; Tension; Frequency of harmonics on a string fixed at both ends; Frequency of harmonics on a string fixed at one end and free at the other end) from 9 known variables:
 ```rpl
@@ -8950,7 +8950,7 @@ A string being fixed or free at its ends admits only discrete harmonics as stand
 
 #### Sound Wave Harmonics
 
-A tube being open or closed at its ends admits only discrete harmonics as standing waves of the sound in the air within the tube. A tube being open (or closed) at both ends admits all integer harmonics. A tube being being open at one end and closed at the other end admits only all odd integer harmonics.
+A tube open or closed at its ends admits only discrete harmonics as standing waves of the sound in the air within the tube. A tube open (or closed) at both ends admits all integer harmonics. A tube open at one end and closed at the other end admits only all odd integer harmonics.
 
 * To calculate `[v_m/s;k_(r/m);ω_(r/s);Tair_°C;s_m;fopenopen_Hz;fopenclose_Hz]` (Propagation speed of sound waves; Wave number; Angular frequency, Temperature; Frequency of harmonics in a tube open at both ends; Frequency of harmonics in a tube open at one end and close at the other end) from 8 known variables:
 ```rpl
@@ -9412,7 +9412,7 @@ The 43 variables in the Modern Physics section are :
 
 #### Planck & Wien Comparison
 
-In this section, two comparisons are done between the Planck and Wien spectral distributiona. Based on a incomplete thermodynamic argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distribution differs notably or agree. The asymptotic agreement for large frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding enissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, For the Planck distribution, one can choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
+In this section, two comparisons are done between the Planck and Wien spectral distributions. Based on an incomplete thermodynamic argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distributions differ notably or agree. The asymptotic agreement for large frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding emissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, for the Planck distribution, one can choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
 
 ![Planck & Wien Comparison](img/Planck_and_Wien_Distributions.bmp)
 
@@ -9425,7 +9425,7 @@ T=1273.15_K  A=100_cm^2  fa=7.48475 43283 5⁳¹³ Hz  fb=3.18337 69964�
 
 #### Planck & Rayleigh-Jeans Comparison
 
-In this section, two comparisons are done between the Planck and Rayleigh-Jeans spectral distributiona. Based on the equipartition theorem argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distribution agree or differs considerably, leading to a divergence called UV catastrophy corresponding to unphysical fractions greather than one. The asymptotic agreement for small frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding enissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, For the Planck distribution, one could choose any other values for `fa` & `fb` and computes the corresponding `FrPlab`, `ebfafb` and `q`.
+In this section, two comparisons are done between the Planck and Rayleigh-Jeans spectral distributions. Based on the equipartition theorem argument, the latter is an approximation of the true Planck law describing the spectral distribution for the light emitted by a black-body. The choice of temperature `T` determines the frequency ranges for integration between `f1` & `f2`, or between `f3` & `f4`. One shall determine in which frequency interval both distributions agree or differ considerably, leading to a divergence called UV catastrophe corresponding to unphysical fractions greater than one. The asymptotic agreement for small frequency is clearly illustrated in the picture. The user is free to choose one or the other comparison fractions (replacing it in `Frfafb`) to compute the corresponding emissive power `ebfafb` and the heat transfer rate `q` from the black-body. Or, for the Planck distribution, one could choose any other values for `fa` & `fb` and compute the corresponding `FrPlab`, `ebfafb` and `q`.
 
 ![Planck & Rayleigh-Jeans Comparison](img/Planck_and_Rayleigh-Jeans_Distributions.bmp)
 
@@ -9438,7 +9438,7 @@ T=1273.15_K  A=100_cm^2  fa=2.65281 41636 9⁳¹⁰ Hz  fb=7.48475 43283
 
 #### Photoelectric Effect
 
-Einstein explained the photoelectric effect with the energy quantification of the electromagnetic wave. The photoelectron is then emitted only if the energy `E` of the incident photon is greather or equal to the work function `φ` of the material. A simple energy budget equation determines the maximum kinetic energy `Kmax` of the photoelectron.
+Einstein explained the photoelectric effect with the energy quantification of the electromagnetic wave. The photoelectron is then emitted only if the energy `E` of the incident photon is greater or equal to the work function `φ` of the material. A simple energy budget equation determines the maximum kinetic energy `Kmax` of the photoelectron.
 
 * To calculate `[f_THz;Eph_eV;f0_THz;λ0_nm;Kmax_eV;Vo_V;vmax_m/s]` (Frequency, Photon energy; Threshold frequency; Threshold wavelength; Maximum kinetic energy of photoelectron; Stoping potential; Maximum speed of photoelectron) from 2 known variables:
 ```rpl
@@ -14966,7 +14966,7 @@ If equations can be solved one at a time, then the `Root` command will use the
 multiple equation solver to solve them in turn.
 
 For example, in the following code, the multiple equation solver can first solve
-for `y` using the second equation, the solve for `x`. In both cases, it can use
+for `y` using the second equation, then solve for `x`. In both cases, it can use
 the `Isolate` command to get an exact expression for the solution.
 
 ```rpl
@@ -14978,7 +14978,7 @@ the `Isolate` command to get an exact expression for the solution.
 
 If equations cannot be solved one at a time, then the `Root` command will
 compute the Jacobian of the equations given as input, and use that to solve the
-systerm iteratively. This is necessary when there is "crosstalk" between
+system iteratively. This is necessary when there is "crosstalk" between
 variables across equations.
 
 For example, to find the coordinates of the intersection between two circles,
@@ -16962,7 +16962,7 @@ the command line, or a list containing up to three elements:
 * The object defining the initial content of the command line
 * A cursor position on the command line, the index starting at 1, where 0 is the
   end of the command-line; or a list or array containing the row and column,
-  starting at 1, where 0 indicates the end of of the row or the last column.
+  starting at 1, where 0 indicates the end of the row or the last column.
 * A validation object
 
 The validation object indicates how the input is validated. If the validation
@@ -16972,7 +16972,7 @@ case-insensitive):
 * `α`, `alpha` or `text` selects text mode and enable alpha mode. The
   value is retured as text.
 * `alg`, `algebraic` or `expression` selects algebraic mode, which can be used
-  to to enter an expression. The value is returned as text for `alg` (for
+  to enter an expression. The value is returned as text for `alg` (for
   compatibility with HP), as an algebraic value (including numbers) if
   `algebraic` is used, as an expression object for `expression` is used.
 * `value` or `object` checks that the command line describes a single valid RPL

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -2991,11 +2991,11 @@ implements, and differ from the HP RPL implementation in the following ways:
 
 * In order to support the computer-related units better, also recognize the
   [power-of-two variants](https://en.wikipedia.org/wiki/Kilobyte),
-  e.g. `1_kiB` is `1024_B`. Also recogize the `K` prefix in addition to `k`.
+  e.g. `1_kiB` is `1024_B`. Also recognize the `K` prefix in addition to `k`.
 
 ### Units file
 
-The built-in units can be overriden by your own set of units, which is defined
+The built-in units can be overridden by your own set of units, which is defined
 in a CSV file called `config/units.csv` in the calculator. CSV stands for "Comma
 separated values, and is a common interchange format for spreadsheet data.
 
@@ -3018,7 +3018,7 @@ to convert between various monetary units:
 * Rows in a file containing a single value denote unit menus, unless the value
   begins with an `=` sign.
 
-* Rows in a file containing two ore more values denote unit menu entries, which
+* Rows in a file containing two or more values denote unit menu entries, which
   will be added to the previous menu.
 
 * The first column in these rows give the name of the unit as shown in the menu.
@@ -3037,11 +3037,11 @@ another. For example, you can convert between `GBP` and `AUD` because they both
 have the same `USD` base unit.
 
 The commands `ShowBuiltinUnits` and `HideBuiltinUnits` indicate if the built-in
-uits should be shown after the units loaded from the file. The default is that
+units should be shown after the units loaded from the file. The default is that
 when a units file is present, the built-in units are hidden. This only affects
 the menus. Built-in units can always be used in expressions if they are typed
 manually. However, units loaded from file will be looked up first, so that a
-built-in unit can be overriden by the units file, which can be useful if a
+built-in unit can be overridden by the units file, which can be useful if a
 definition changes like the US Survey foot changed on January 1st, 2023.
 
 If you build a units file, it is recommended that you do not exceed 17 unit
@@ -12271,13 +12271,13 @@ calculator operations.
 ```
 # Library Management
 
-DB48x features a [library](#library) that can contain arbitary RPL code,
+DB48x features a [library](#library) that can contain arbitrary RPL code,
 which is made readily available for use in your programs.
 
 References to library functions are efficient both in terms of memory usage and
 execution speed.  Typically, a reference to a library item takes 2 or 3 bytes,
 and evaluating it is as fast as if it was on the stack, and faster than if
-storedin a global variable.
+stored in a global variable.
 
 Library items are also shared across DB48x states.
 
@@ -12285,13 +12285,13 @@ A key aspect of the execution speed for library items is that they are loaded
 from disk only once, and then cached in compiled form in memory. This is how the
 next uses of that library item can be as fast as if it was on the stack.
 
- Library items that are currently loaded in memory can be identified using
-`Libs`. The `Attach` commadn can be used to load items ahead of time. The
+Library items that are currently loaded in memory can be identified using
+`Libs`. The `Attach` command can be used to load items ahead of time. The
 `Detach` command can be used to evacuate library elements that are no longer
 used.
 
 When you modify the content of the library, you can use the following sequence
-to make sure that the new version of thelibrary items are reloaded from disk:
+to make sure that the new version of the library items are reloaded from disk:
 
 ```rpl
 LIBS DUP DETACH ATTACH
@@ -16246,7 +16246,7 @@ power, because of additional animations or more expensive graphical rendering.
 ## Bytes
 
 Return the size of the object and a hash of its value. On classic RPL systems,
-teh hash is a 5-nibbles CRC32. On DB50X, the hash is a based integer of the
+the hash is a 5-nibbles CRC32. On DB50X, the hash is an integer based on the
 current [wordsize](#stws) corresponding to the binary representation of the
 object.
 
@@ -16260,7 +16260,7 @@ value of the integer, and `xx` represents the integer type, as returned by the
 ## Type
 
 Return the type of the object as a numerical value. The value is not guaranteed
-to be portable across versions of DB50X (and pretty much is guarantteed to _not_
+to be portable across versions of DB50X (and pretty much is guaranteed to _not_
 be portable at the current stage of development).
 
 ### HP-compatible types
@@ -17195,14 +17195,14 @@ When `UserModeLock` is selected, each use toggles user mode on or off.
 ## KeyMap
 
 Key assignments on DB48x are not global, unlike what happens with `ASN` on HP
-claculators. Instead, assignments are stored in a special variable (really a
+calculators. Instead, assignments are stored in a special variable (really a
 directory containing numbered variables) called `KeyMap`. This approach makes it
 possible to have per-directory key assignments, and to use normal tools such as
 `Store` and `Recall` to manipulate key assignments.
 
 If a `KeyMap` is present in the current directory, it overrides assignments
 while you are in that directory. However, key assignments from the enclosing
-directories are still considered when they are not overriden. In other words,
+directories are still considered when they are not overridden. In other words,
 key assignments are a hierarchy. When no key assignment is found in any of the
 `KeyMap` variables in any of the enclosing directories, then the default key
 binding for that key applies.


### PR DESCRIPTION
While using the simulator, I found some spelling errors in the built-in help. Then I ran all the files through Codex Pro. I manually verified that the corrections look good.