### PR TITLE
WASM: Enable built-in help functionality (and others) by populating the virtual filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,9 @@ CFLAGS += 	-O3 -pthread
 LDFLAGS +=	-s MODULARIZE=0				\
 		-s RESERVED_FUNCTION_POINTERS=20	\
 		-s PTHREAD_POOL_SIZE=4			\
-		--bind -pthread
+		--bind -pthread \
+		--embed-file config \
+		--embed-file help
 
 #------------------------------------------------------------------------------
 else


### PR DESCRIPTION
Some features like the built-in help depend on file access within `config` and `help` directories.
This PR populates the emscripten virtual file system by embedding those directories in the final produced binary so those features work in the web.