### PR TITLE
UX: Reseting scroll state when exiting SHOW command

### DIFF
--- a/src/graphics.cc
+++ b/src/graphics.cc
@@ -1325,6 +1325,8 @@ object::result show(object_r obj)
 #endif // SIMULATOR && !WASM
             }
         }
+        show_x = 0;
+        show_y = 0;
         sys_timer_disable(TIMER0);
         sys_timer_disable(TIMER1);
         redraw_lcd(true);


### PR DESCRIPTION
At first glance, I thought it was a bug.

If you enter a "tall" equation like this: `'1÷2÷3÷4÷5÷6÷7÷8÷9÷10÷11÷12÷13÷14÷15÷16'`
Then press `SHOW` and scroll down to the bottom.
Then exit `SHOW` and enter a "short" equation like `'2+2'`
Then press `SHOW`, you expect to see the new equation but nothing is rendered (you actually need to scroll to the very up to see the equation)

This fix resets the scroll position when you exit `SHOW` mimicking what the 50g's `VIEW` command does and what I expect to happen.