### PR TITLE
complex: Fix expm1 formula computing exp(z-1) instead of exp(z)-1

### DIFF
--- a/src/complex.cc
+++ b/src/complex.cc
@@ -1272,7 +1272,7 @@ COMPLEX_BODY(expm1)
 // ----------------------------------------------------------------------------
 {
     complex_g one = complex::make(1, 0);
-    return exp(z - one);
+    return exp(z) - one;
 }
 
 

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -5101,6 +5101,18 @@ void tests::complex_functions()
     test(ID_exp)
         .expect("18.43908 89145 85774 62∡0.86217 00546 67226 34884ʳ");
 
+    step("Complex exponential minus 1 (zero)");
+    test(CLEAR, "0+0ⅈ expm1", ENTER)
+        .expect("0+0ⅈ");  // expm1(0) = e^0 - 1 = 0
+
+    step("Complex exponential minus 1 (real)");
+    test(CLEAR, "1+0ⅈ expm1", ENTER)
+        .match("1\\.71828.*\\+0ⅈ");  // e - 1
+
+    step("Complex exponential minus 1 (imaginary)");
+    test(CLEAR, "0+3.14159265358979323846ⅈ expm1", ENTER)
+        .match("-2\\..*ⅈ");  // expm1(πi) ≈ -2 (with tiny floating point error)
+
     step("Power");
     test(CLEAR, "3+7ⅈ", ENTER, "2-3ⅈ", ID_pow)
         .expect("1 916.30979 15541 96293 8∡2.52432 98723 79583 8639ʳ");


### PR DESCRIPTION
## Summary
- Fix mathematical error in complex `expm1` function
- Add tests for complex `expm1` to prevent regression

## Problem
The complex implementation of `expm1(z)` incorrectly computed `e^(z-1)` instead of `e^z - 1`.

For example:
- `expm1(0)` returned `e^(-1) ≈ 0.3679` instead of `0`
- `expm1(1)` returned `e^0 = 1` instead of `e - 1 ≈ 1.7183`

## Fix
Changed `src/complex.cc` line 1275 from `exp(z - one)` to `exp(z) - one`.

## Known Limitations
This fix corrects the formula but is still a temporary solution. For small values of `z`, computing `exp(z) - 1` directly suffers from catastrophic cancellation. A proper implementation should use a numerically stable algorithm (e.g., Taylor series for small `|z|`).

## Testing
- Added 3 new tests for complex expm1 in `complex_functions()`
- Ran full test suite with `-T` flag - no regressions