### PR TITLE
Fix issue #1605

### DIFF
--- a/src/utf8.h
+++ b/src/utf8.h
@@ -308,7 +308,7 @@ inline bool utf8_whitespace(unicode cp)
 //   Check if something is a whitespace
 // ----------------------------------------------------------------------------
 {
-    return cp == ' ' || cp == '\n' || cp == '\t';
+    return cp == ' ' || cp == '\n' || cp == '\r' || cp == '\t';
 }
 
 


### PR DESCRIPTION
In order to be able to parse source code written by Microsoft Windows applications such as Notepad, where end-of-line are CR/LF, treat both CR and LF as whitespace.

See discussion in issue #1605.