### PR TITLE
Fix TVMBeg and TVMEnd formulas in equations.cc

### DIFF
--- a/src/equations.cc
+++ b/src/equations.cc
@@ -1397,8 +1397,8 @@ static const cstring basic_equations[] =
 
 
     "Finance", nullptr,
-    "TVMBeg", "'(1+I%Yr/(100*PYr))*(100*PYr)/I%Yr*Pmt*(1-(1+I%Yr/(100*PYr))^(-n))+FV*(1+I%Yr/(100*PYr))^(-n)+PV'",
-    "TVMEnd", "'(100*PYr)/I%Yr*Pmt*(1-(1+I%Yr/(100*PYr))^(-n))+FV*(1+I%Yr/(100*PYr))^(-n)+PV'",
+    "TVMBeg", "'(1+I%Yr/(100*PYr))*(100*PYr)/I%Yr*Pmt*(1-(1+I%Yr/(100*PYr))^(-n))-FV*(1+I%Yr/(100*PYr))^(-n)+PV'",
+    "TVMEnd", "'(100*PYr)/I%Yr*Pmt*(1-(1+I%Yr/(100*PYr))^(-n))-FV*(1+I%Yr/(100*PYr))^(-n)+PV'",
 
     // As of 24-11-12: Total 695 vars, 614 eqns, 163 sims in 18 sections (eqns: 614/315=1.95; vars: 693/397=1.75 )
     // As of 24-12-11: Total 724 vars, 644 eqns, 182 sims in 158 subsections, 18 sections (644/315=2.04; 724/397=1.82)


### PR DESCRIPTION
The sign of FV is incorrect in the TVMBeg and TVMEnd formulas. One can confirm this by considering the limit case of `I%Yr=0`, which should degenerate into `PresentValue + Pmt = FutureValue`, or, using the notations of the calculator `Pmt - FV + PV = 0`.

I had only done a few computations with FV=0 until recently, and the bug appeared to me as I started having examples with non-zero FV.