### PR TITLE
Fixes #1593: DB48X keyboard not visible on Samsung Galaxy S23 Ultra

### DIFF
--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui.screen->setAttribute(Qt::WA_AcceptTouchEvents);
     ui.screen->installEventFilter(this);
     ui.keyboard->setStyleSheet("border-image: "
-                               "url(:/bitmap/keyboard-db48x.png) "
+                               "url(:/bitmap/keymap.png) "
                                "0 0 0 0 stretch stretch;");
 
     highlight = new Highlight(ui.keyboard);


### PR DESCRIPTION
simulator: Refer to keyboard image using alias keymap.png

sim/sim-window.cpp:MainWindow::MainWindow set a border-image URL referring to the keymap image using the actual file name which works in the desktop case. However, Android bundles are strict about resources and the correct way to refer to the image is using the alias keymap.png. This change enables the keyboard to be displayed both on desktop and Android devices like phones.