### PR TITLE
Implementation of "DFC" / "DFC2F" (Continued fractions)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,7 @@ CXX_SOURCES +=				\
 	src/complex.cc			\
 	src/conditionals.cc		\
 	src/constants.cc		\
+	src/continued-fraction.cc \
 	src/custom.cc		 	\
 	src/datetime.cc			\
 	src/decimal.cc			\

--- a/sim/db48x.pro
+++ b/sim/db48x.pro
@@ -49,6 +49,7 @@ SOURCES +=                                      \
         ../src/complex.cc                       \
         ../src/conditionals.cc                  \
         ../src/constants.cc                     \
+        ../src/continued-fraction.cc            \
         ../src/custom.cc                        \
         ../src/datetime.cc                      \
         ../src/decimal.cc                       \

--- a/src/continued-fraction.cc
+++ b/src/continued-fraction.cc
@@ -10,19 +10,16 @@
 //       x = a0 + 1/(a1 + 1/(a2 + 1/...))
 //     and returns the list of coefficients [a0, a1, a2, ...].
 //
-//     Algorithm for integers and fractions (exact):
-//       Standard Euclidean algorithm on the numerator and denominator.
-//
-//     Algorithm for decimals and other reals:
-//       1. Split x into integer part ip (truncated toward zero) and fp = x - ip
-//       2. For negative non-integer x, adjust so fp stays in [0, 1):
-//            ip = floor(x) = truncate(x) - 1
-//            fp = 1 + fractional_part   (which is 1 - |fractional_part|)
-//       3. Append ip as a0.
-//       4. Iterate: next = 1/fp, ip = floor(next), fp = next - ip.
-//          Append ip as next coefficient.
-//       5. Stop when fp is zero or when |fp| < 10^(-sdigs)
-//          where sdigs = significant_digits(input).
+//     Algorithm for integers:   trivial – one-element list.
+//     Algorithm for fractions:  exact Euclidean algorithm on numerator/denominator.
+//     Algorithm for decimals:   exact bignum Euclidean algorithm.
+//       The decimal x is converted to an exact rational mant/10^denom_exp,
+//       and the standard Euclidean GCD algorithm is applied.  Iteration stops
+//       (before appending) when the next convergent denominator Q_{k+1} would
+//       exceed 10^(eff_exp/2), where eff_exp = significant_digits(x) − xe is
+//       the effective denominator exponent.  Coefficients beyond that threshold
+//       belong to the finite decimal approximation, not the true mathematical
+//       value, and are discarded.
 //
 // ****************************************************************************
 //   This software is licensed under the terms outlined in LICENSE.txt
@@ -38,16 +35,143 @@
 #include "integer.h"
 #include "list.h"
 
+
+// ----------------------------------------------------------------------------
+//   Convert a bignum coefficient to integer when it fits, bignum otherwise.
+//   Required because == does byte-level comparison: bignum(2) ≠ integer(2).
+// ----------------------------------------------------------------------------
+static algebraic_g bignum_to_algebraic(bignum_g n)
+{
+    if (integer_p small = (+n)->as_integer())
+        return algebraic_p(small);
+    return algebraic_p(+n);
+}
+
+
+// ----------------------------------------------------------------------------
+//   Core DFC algorithm for a decimal value.
+//   Appends CF coefficients [a0, a1, …] to the current scribble area.
+//   Returns object::OK or object::ERROR.
+// ----------------------------------------------------------------------------
+static object::result
+dfc_decimal(decimal_g dec, bool neg)
+{
+    // Build the mantissa integer from kigits.
+    // Re-fetch shape() each iteration: bignum allocations can trigger GC and
+    // move the decimal object (dec is a GC root so +dec stays valid, but a
+    // locally cached xi.base pointer would go stale).
+    decimal::info xi    = (+dec)->shape();
+    size_t        xs    = xi.nkigits;
+    large         xe    = xi.exponent;
+    bignum_g      mant  = bignum::make(0);
+    bignum_g      k1000 = bignum::make(1000);
+    bignum_g      k10   = bignum::make(10);
+    for (size_t i = 0; i < xs; i++)
+    {
+        decimal::info xi_now = (+dec)->shape();
+        bignum_g      kbig   = bignum::make(decimal::kigit(xi_now.base, i));
+        bignum_g      prod   = mant * k1000;
+        mant = prod + kbig;
+    }
+
+    // Represent value as exact rational mant / 10^denom_exp.
+    bignum_g p, q;
+    large denom_exp = (large)(3 * xs) - xe;
+    if (denom_exp > 0)
+    {
+        q = bignum::make(1);
+        for (large i = 0; i < denom_exp; i++)
+            q = q * k10;
+        p = mant;
+    }
+    else
+    {
+        p = mant;
+        for (large i = 0; i < -denom_exp; i++)
+            p = p * k10;
+        q = bignum::make(1);
+    }
+
+    // First coefficient a0 = floor(±p/q), keeping fp = fractional part ≥ 0.
+    bignum_g    quot  = p / q;
+    bignum_g    rem   = p % q;
+    algebraic_g a0;
+    bignum_g    next_p, next_q;
+    if (neg && !rem->is_zero())
+    {
+        // floor(-p/q) = −(quot+1);  fractional part = (q − rem)/q
+        bignum_g one   = bignum::make(1);
+        bignum_g quot1 = quot + one;
+        bignum_g neg_a = -quot1;
+        a0     = bignum_to_algebraic(neg_a);
+        next_p = q - rem;
+        next_q = q;
+    }
+    else if (neg)
+    {
+        // Exact negative integer
+        bignum_g neg_a = -quot;
+        a0     = bignum_to_algebraic(neg_a);
+        next_p = bignum::make(0);
+        next_q = bignum::make(1);
+    }
+    else
+    {
+        a0     = bignum_to_algebraic(quot);
+        next_p = rem;
+        next_q = q;
+    }
+    if (!a0 || !rt.append(a0))
+        return object::ERROR;
+
+    // Stopping threshold: 10^(eff_exp/2).
+    // eff_exp = significant_digits(x) − xe is the exponent of the effective
+    // denominator (after cancelling trailing kigit-padding zeros from the
+    // mantissa).  When precision P is not a multiple of 3, kigit alignment
+    // adds trailing zeros, making the kigit-based denom_exp too large; using
+    // significant_digits() corrects this and prevents garbage coefficients.
+    bignum_g thresh  = bignum::make(1);
+    large    eff_exp = (large) dec->significant_digits() - xe;
+    size_t   tlim    = (eff_exp > 0) ? (size_t)(eff_exp / 2) : 0;
+    for (size_t ti = 0; ti < tlim; ti++)
+        thresh = thresh * k10;
+
+    // Euclidean loop.  Q_prev = Q_{k-1}, Q_curr = Q_k are the convergent
+    // denominators.  Stop BEFORE appending a_k when Q_{k+1} > thresh: such
+    // coefficients belong to the finite decimal approximation, not to the
+    // true mathematical value.
+    bignum_g Q_prev = bignum::make(0);
+    bignum_g Q_curr = bignum::make(1);
+    p = next_q;
+    q = next_p;
+    while (!q->is_zero())
+    {
+        bignum_g ai_big = p / q;
+        bignum_g r      = p % q;
+        bignum_g tmp    = ai_big * Q_curr;
+        bignum_g Q_new  = tmp + Q_prev;
+        if (Q_new > thresh)
+            break;
+        algebraic_g ai = bignum_to_algebraic(ai_big);
+        if (!ai || !rt.append(ai))
+            return object::ERROR;
+        Q_prev = Q_curr;
+        Q_curr = Q_new;
+        p = q;
+        q = r;
+    }
+    return object::OK;
+}
+
+
 COMMAND_BODY(DFC)
 // ----------------------------------------------------------------------------
 //   Decompose a real number into its continued fraction coefficients
 // ----------------------------------------------------------------------------
 {
-    // Fetch the input from the stack
     algebraic_g xo = algebraic_p(strip(rt.stack(0)));
     if (!xo)
         return ERROR;
-
     object::id ty = xo->type();
 
     // -----------------------------------------------------------------------
@@ -65,64 +189,57 @@ COMMAND_BODY(DFC)
     }
 
     // -----------------------------------------------------------------------
-    // Fast path 2: small fraction → exact Euclidean algorithm
-    //   Only for ID_fraction / ID_neg_fraction (numerator and denominator
-    //   both fit in ularge).  Big fractions fall through to the decimal path.
+    // Fast path 2: small fraction → exact Euclidean (native integer arithmetic)
+    //   Only for ID_fraction / ID_neg_fraction (num and denom fit in ularge).
+    //   Big fractions fall through to the decimal path below.
     // -----------------------------------------------------------------------
     if (ty == object::ID_fraction || ty == object::ID_neg_fraction)
     {
-        fraction_p frac  = fraction_p(+xo);
-        ularge     p     = frac->numerator_value();   // absolute value
-        ularge     q     = frac->denominator_value(); // always positive
-        bool       neg   = (ty == object::ID_neg_fraction);
+        fraction_p frac   = fraction_p(+xo);
+        ularge     p      = frac->numerator_value();
+        ularge     q      = frac->denominator_value();
+        bool       neg    = (ty == object::ID_neg_fraction);
+        scribble   scr;
 
-        scribble scr;
-
-        // First coefficient: floor(±p/q) with correct sign handling
-        ularge    quot0 = p / q;
-        ularge    rem0  = p % q;
+        ularge    quot  = p / q;
+        ularge    rem   = p % q;
         ularge    next_p, next_q;
         integer_g a0i;
-
-        if (neg && rem0 != 0)
+        if (neg && rem != 0)
         {
-            // floor(-p/q) = -(p/q + 1); fractional part = (q - rem0)/q
-            a0i    = rt.make<neg_integer>(quot0 + 1);
-            next_p = q - rem0;
+            // floor(−p/q) = −(quot+1);  fractional part = (q − rem)/q
+            a0i    = rt.make<neg_integer>(quot + 1);
+            next_p = q - rem;
             next_q = q;
         }
         else if (neg)
         {
-            // Exact negative integer: floor(-p/q) = -(p/q), fp = 0
-            a0i    = rt.make<neg_integer>(quot0);
+            a0i    = rt.make<neg_integer>(quot);
             next_p = 0;
             next_q = 1;
         }
         else
         {
-            // Non-negative: floor(p/q) = p/q
-            a0i    = rt.make<integer>(quot0);
-            next_p = rem0;
+            a0i    = rt.make<integer>(quot);
+            next_p = rem;
             next_q = q;
         }
         if (!a0i || !rt.append(a0i))
             return ERROR;
 
-        // Remaining coefficients via the Euclidean algorithm.
-        // The fractional part is next_p/next_q; its reciprocal is next_q/next_p.
+        // Remaining coefficients: reciprocal swap then standard GCD steps.
         p = next_q;
         q = next_p;
         while (q != 0)
         {
-            ularge    a_val = p / q;
-            ularge    r     = p % q;
-            integer_g ai    = rt.make<integer>(a_val);
+            ularge    a  = p / q;
+            ularge    r  = p % q;
+            integer_g ai = rt.make<integer>(a);
             if (!ai || !rt.append(ai))
                 return ERROR;
             p = q;
             q = r;
         }
-
         list_g lst = list::make(scr.scratch(), scr.growth());
         if (!lst || !rt.top(lst))
             return ERROR;
@@ -130,302 +247,34 @@ COMMAND_BODY(DFC)
     }
 
     // -----------------------------------------------------------------------
-    // Fast path 3: decimal input → exact Euclidean algorithm
+    // Decimal and general path: ensure we have a decimal, then apply the
+    // exact bignum Euclidean algorithm via dfc_decimal().
     //
-    //   The floating-point iterative algorithm is numerically unstable for
-    //   slowly-converging CFs (e.g. sqrt(2) = [1;2,2,2,…]) because the CF
-    //   map x→1/x−floor(1/x) amplifies errors by 1/fp² ≈ 5.83 per step.
-    //   After about 30 steps with 34-digit arithmetic the result is garbage.
-    //
-    //   Instead we convert the decimal exactly to a bignum fraction
-    //     value = mantissa_integer × 10^(exponent − 3×nkigits)
-    //   and apply the same Euclidean GCD algorithm used for ID_fraction.
-    //   This gives a perfectly stable, terminating CF with zero rounding
-    //   error, so DFC2F(DFC(x)) == x for any decimal x.
+    //   The floating-point iterative approach (x → 1/fp − floor(1/fp)) is
+    //   numerically unstable: the CF map amplifies errors by 1/fp² ≈ 5.83
+    //   per step, so after ~30 steps with 34-digit arithmetic the result is
+    //   garbage.  Converting to an exact bignum rational first avoids this.
     // -----------------------------------------------------------------------
-    if (ty == object::ID_decimal || ty == object::ID_neg_decimal)
+    if (ty != object::ID_decimal && ty != object::ID_neg_decimal)
     {
-        decimal_g dec = decimal_p(+xo);
-        decimal::info xi = (+dec)->shape();
-        size_t xs  = xi.nkigits;
-        large  xe  = xi.exponent;
-        bool   neg = (ty == object::ID_neg_decimal);
-
-        // Build the mantissa integer: mant = kigit(0)×1000^(xs-1) + … + kigit(xs-1)
-        // kigit(0) is the most-significant (value × 10^xe).
-        // We re-fetch shape() inside the loop because bignum allocations can
-        // trigger GC, which may move the decimal object (dec is GC-tracked,
-        // so +dec is always updated; xi.base would become stale after a GC).
-        bignum_g mant  = bignum::make(0);
-        bignum_g k1000 = bignum::make(1000);
-        bignum_g k10   = bignum::make(10);
-        for (size_t i = 0; i < xs; i++)
+        if (!algebraic::to_decimal(xo))
         {
-            decimal::info    xi_now = (+dec)->shape();
-            decimal::kint    xk     = decimal::kigit(xi_now.base, i);
-            bignum_g         kbig   = bignum::make(xk);
-            bignum_g         prod   = mant * k1000;
-            mant = prod + kbig;
-        }
-
-        // Exact value = mant / 10^(3×xs − xe)   (denominator side)
-        //             = mant × 10^(xe − 3×xs)    (numerator side, if xe > 3×xs)
-        bignum_g p, q;
-        large denom_exp = (large)(3 * xs) - xe; // positive → denominator = 10^denom_exp
-        if (denom_exp > 0)
-        {
-            q = bignum::make(1);
-            for (large i = 0; i < denom_exp; i++)
-                q = q * k10;
-            p = mant;
-        }
-        else
-        {
-            p = mant;
-            for (large i = 0; i < -denom_exp; i++)
-                p = p * k10;
-            q = bignum::make(1);
-        }
-
-        // First coefficient: floor(±p/q) with correct sign handling
-        scribble scr;
-        bignum_g  quot   = p / q;
-        bignum_g  rem    = p % q;
-        algebraic_g a0;
-        bignum_g next_p, next_q;
-
-        if (neg && !rem->is_zero())
-        {
-            // floor(-p/q) = -(quot+1),  fractional part = (q−rem)/q
-            bignum_g one1   = bignum::make(1);
-            bignum_g quot1  = quot + one1;
-            bignum_g neg_q1 = -quot1;
-            if (integer_p small = (+neg_q1)->as_integer())
-                a0 = algebraic_p(small);
-            else
-                a0 = algebraic_p(+neg_q1);
-            next_p = q - rem;
-            next_q = q;
-        }
-        else if (neg)
-        {
-            // Exact negative integer
-            bignum_g neg_q = -quot;
-            if (integer_p small = (+neg_q)->as_integer())
-                a0 = algebraic_p(small);
-            else
-                a0 = algebraic_p(+neg_q);
-            next_p = bignum::make(0);
-            next_q = bignum::make(1);
-        }
-        else
-        {
-            if (integer_p small = (+quot)->as_integer())
-                a0 = algebraic_p(small);
-            else
-                a0 = algebraic_p(+quot);
-            next_p = rem;
-            next_q = q;
-        }
-        if (!a0 || !rt.append(a0))
+            rt.type_error();
             return ERROR;
-
-        // Remaining coefficients: Euclidean GCD on (next_q, next_p).
-        // Track convergent denominators Q_prev/Q_curr: stop when Q_curr
-        // exceeds 10^(denom_exp/2).  The CF of the decimal rational p/q
-        // agrees with the CF of the true value x only while
-        //   Q_k < sqrt(q)  =  10^(denom_exp/2),
-        // beyond that the coefficients are garbage (specific to the finite
-        // decimal approximation).  Using denom_exp/2, not 3*xs/2, correctly
-        // accounts for the actual denominator exponent (xe shifts the boundary).
-        bignum_g Q_prev = bignum::make(0);   // Q_{-1} = 0
-        bignum_g Q_curr = bignum::make(1);   // Q_0 = 1
-        bignum_g thresh = bignum::make(1);
-        // Use significant_digits() rather than nkigits*3 so that the threshold
-        // sqrt(effective_denominator) is based on the actual precision P, not
-        // on the kigit-padded digit count.  When P is not a multiple of 3 the
-        // last kigit has trailing zero digits that make the kigit-based
-        // denom_exp larger than the effective denominator exponent (sd − xe),
-        // causing the threshold to exceed the CF breakdown boundary and
-        // admitting spurious "garbage" coefficients at the end of the list.
-        unsigned sd      = dec->significant_digits();
-        large    eff_exp = (large) sd - xe;  // effective denominator exponent
-        size_t   tlim    = (eff_exp > 0) ? (size_t)(eff_exp / 2) : 0;
-        for (size_t ti = 0; ti < tlim; ti++)
-            thresh = thresh * k10;
-
-        p = next_q;
-        q = next_p;
-        while (!q->is_zero())
-        {
-            bignum_g ai_big = p / q;
-            bignum_g r      = p % q;
-            // Q_{k+1} = a_k * Q_k + Q_{k-1}.
-            // Check BEFORE appending: coefficients whose convergent denominator
-            // Q_{k+1} > sqrt(q) = thresh may belong to the finite-decimal
-            // approximation rather than the true irrational.  Stopping before
-            // such a coefficient avoids spurious trailing terms.
-            bignum_g tmp   = ai_big * Q_curr;
-            bignum_g Q_new = tmp + Q_prev;
-            if (Q_new > thresh)
-                break;
-            // Normalise to small integer when it fits (so that == on lists works).
-            algebraic_g ai;
-            if (integer_p small = (+ai_big)->as_integer())
-                ai = algebraic_p(small);
-            else
-                ai = algebraic_p(+ai_big);
-            if (!ai || !rt.append(ai))
-                return ERROR;
-            Q_prev = Q_curr;
-            Q_curr = Q_new;
-            p = q;
-            q = r;
         }
-
-        list_g lst = list::make(scr.scratch(), scr.growth());
-        if (!lst || !rt.top(lst))
-            return ERROR;
-        return OK;
+        ty = xo->type();
+        xo = algebraic_p(+xo);
     }
 
-    // -----------------------------------------------------------------------
-    // General path: convert to decimal, then use the exact Euclidean algorithm.
-    // This handles symbolic constants (pi, e, …) and any other type that can
-    // be evaluated numerically.  Converting to decimal first, then applying
-    // the exact bignum Euclidean algorithm, avoids the floating-point
-    // instability of the iterative 1/fp approach.
-    // -----------------------------------------------------------------------
-    if (!algebraic::to_decimal(xo))
-    {
-        rt.type_error();
+    scribble  scr;
+    decimal_g dec = decimal_p(+xo);
+    result r = dfc_decimal(dec, ty == object::ID_neg_decimal);
+    if (r != OK)
+        return r;
+    list_g lst = list::make(scr.scratch(), scr.growth());
+    if (!lst || !rt.top(lst))
         return ERROR;
-    }
-
-    // Re-read the type and fall through to the exact decimal path below.
-    // We reuse fast path 3's logic directly on the converted decimal.
-    ty  = xo->type();
-    xo  = algebraic_p(+xo);
-
-    // Intentional fall-through: the decimal case (fast path 3) handles this.
-    // For clarity the code is repeated here rather than introducing a goto.
-    {
-        decimal_g dec = decimal_p(+xo);
-        decimal::info xi = (+dec)->shape();
-        size_t xs  = xi.nkigits;
-        large  xe  = xi.exponent;
-        bool   neg = (ty == object::ID_neg_decimal);
-
-        bignum_g mant  = bignum::make(0);
-        bignum_g k1000 = bignum::make(1000);
-        bignum_g k10   = bignum::make(10);
-        for (size_t i = 0; i < xs; i++)
-        {
-            decimal::info    xi_now = (+dec)->shape();
-            decimal::kint    xk     = decimal::kigit(xi_now.base, i);
-            bignum_g         kbig   = bignum::make(xk);
-            bignum_g         prod   = mant * k1000;
-            mant = prod + kbig;
-        }
-
-        bignum_g p, q;
-        large denom_exp = (large)(3 * xs) - xe;
-        if (denom_exp > 0)
-        {
-            q = bignum::make(1);
-            for (large i = 0; i < denom_exp; i++)
-                q = q * k10;
-            p = mant;
-        }
-        else
-        {
-            p = mant;
-            for (large i = 0; i < -denom_exp; i++)
-                p = p * k10;
-            q = bignum::make(1);
-        }
-
-        scribble scr;
-        bignum_g  quot   = p / q;
-        bignum_g  rem    = p % q;
-        algebraic_g a0;
-        bignum_g next_p, next_q;
-
-        if (neg && !rem->is_zero())
-        {
-            bignum_g one1   = bignum::make(1);
-            bignum_g quot1  = quot + one1;
-            bignum_g neg_q1 = -quot1;
-            if (integer_p small = (+neg_q1)->as_integer())
-                a0 = algebraic_p(small);
-            else
-                a0 = algebraic_p(+neg_q1);
-            next_p = q - rem;
-            next_q = q;
-        }
-        else if (neg)
-        {
-            bignum_g neg_q = -quot;
-            if (integer_p small = (+neg_q)->as_integer())
-                a0 = algebraic_p(small);
-            else
-                a0 = algebraic_p(+neg_q);
-            next_p = bignum::make(0);
-            next_q = bignum::make(1);
-        }
-        else
-        {
-            if (integer_p small = (+quot)->as_integer())
-                a0 = algebraic_p(small);
-            else
-                a0 = algebraic_p(+quot);
-            next_p = rem;
-            next_q = q;
-        }
-        if (!a0 || !rt.append(a0))
-            return ERROR;
-
-        // Same precision-limited stopping criterion as fast path 3:
-        // use significant_digits()-based effective exponent to avoid
-        // admitting garbage coefficients from kigit trailing-zero padding.
-        bignum_g Q_prev  = bignum::make(0);
-        bignum_g Q_curr  = bignum::make(1);
-        bignum_g thresh  = bignum::make(1);
-        unsigned sd2     = dec->significant_digits();
-        large    eff_exp2 = (large) sd2 - xe;
-        size_t   tlim    = (eff_exp2 > 0) ? (size_t)(eff_exp2 / 2) : 0;
-        for (size_t ti = 0; ti < tlim; ti++)
-            thresh = thresh * k10;
-
-        p = next_q;
-        q = next_p;
-        while (!q->is_zero())
-        {
-            bignum_g ai_big = p / q;
-            bignum_g r      = p % q;
-            // Check BEFORE appending (same reason as fast path 3).
-            bignum_g tmp   = ai_big * Q_curr;
-            bignum_g Q_new = tmp + Q_prev;
-            if (Q_new > thresh)
-                break;
-            algebraic_g ai;
-            if (integer_p small = (+ai_big)->as_integer())
-                ai = algebraic_p(small);
-            else
-                ai = algebraic_p(+ai_big);
-            if (!ai || !rt.append(ai))
-                return ERROR;
-            Q_prev = Q_curr;
-            Q_curr = Q_new;
-            p = q;
-            q = r;
-        }
-
-        list_g lst = list::make(scr.scratch(), scr.growth());
-        if (!lst || !rt.top(lst))
-            return ERROR;
-        return OK;
-    }
+    return OK;
 }
 
 
@@ -440,7 +289,6 @@ COMMAND_BODY(DFC2F)
 //     x = a0 + 1/x
 // ----------------------------------------------------------------------------
 {
-    // Fetch the list from the stack
     object_p obj = strip(rt.stack(0));
     if (!obj)
         return ERROR;
@@ -457,12 +305,10 @@ COMMAND_BODY(DFC2F)
         return ERROR;
     }
 
-    // Start with the last coefficient
     algebraic_g x = algebraic_p(lst->at(n - 1));
     if (!x)
         return ERROR;
 
-    // Process right to left: x = a_i + 1/x
     algebraic_g one = integer::make(1);
     if (!one)
         return ERROR;

--- a/src/continued-fraction.cc
+++ b/src/continued-fraction.cc
@@ -31,6 +31,8 @@
 #include "continued-fraction.h"
 
 #include "algebraic.h"
+#include "arithmetic.h"
+#include "bignum.h"
 #include "decimal.h"
 #include "fraction.h"
 #include "integer.h"
@@ -128,7 +130,144 @@ COMMAND_BODY(DFC)
     }
 
     // -----------------------------------------------------------------------
-    // General path: convert to decimal and use the iterative algorithm
+    // Fast path 3: decimal input → exact Euclidean algorithm
+    //
+    //   The floating-point iterative algorithm is numerically unstable for
+    //   slowly-converging CFs (e.g. sqrt(2) = [1;2,2,2,…]) because the CF
+    //   map x→1/x−floor(1/x) amplifies errors by 1/fp² ≈ 5.83 per step.
+    //   After about 30 steps with 34-digit arithmetic the result is garbage.
+    //
+    //   Instead we convert the decimal exactly to a bignum fraction
+    //     value = mantissa_integer × 10^(exponent − 3×nkigits)
+    //   and apply the same Euclidean GCD algorithm used for ID_fraction.
+    //   This gives a perfectly stable, terminating CF with zero rounding
+    //   error, so DFC2F(DFC(x)) == x for any decimal x.
+    // -----------------------------------------------------------------------
+    if (ty == object::ID_decimal || ty == object::ID_neg_decimal)
+    {
+        decimal_g dec = decimal_p(+xo);
+        decimal::info xi = (+dec)->shape();
+        size_t xs  = xi.nkigits;
+        large  xe  = xi.exponent;
+        bool   neg = (ty == object::ID_neg_decimal);
+
+        // Build the mantissa integer: mant = kigit(0)×1000^(xs-1) + … + kigit(xs-1)
+        // kigit(0) is the most-significant (value × 10^xe).
+        // We re-fetch shape() inside the loop because bignum allocations can
+        // trigger GC, which may move the decimal object (dec is GC-tracked,
+        // so +dec is always updated; xi.base would become stale after a GC).
+        bignum_g mant  = bignum::make(0);
+        bignum_g k1000 = bignum::make(1000);
+        bignum_g k10   = bignum::make(10);
+        for (size_t i = 0; i < xs; i++)
+        {
+            decimal::info    xi_now = (+dec)->shape();
+            decimal::kint    xk     = decimal::kigit(xi_now.base, i);
+            bignum_g         kbig   = bignum::make(xk);
+            bignum_g         prod   = mant * k1000;
+            mant = prod + kbig;
+        }
+
+        // Exact value = mant / 10^(3×xs − xe)   (denominator side)
+        //             = mant × 10^(xe − 3×xs)    (numerator side, if xe > 3×xs)
+        bignum_g p, q;
+        large denom_exp = (large)(3 * xs) - xe; // positive → denominator = 10^denom_exp
+        if (denom_exp > 0)
+        {
+            q = bignum::make(1);
+            for (large i = 0; i < denom_exp; i++)
+                q = q * k10;
+            p = mant;
+        }
+        else
+        {
+            p = mant;
+            for (large i = 0; i < -denom_exp; i++)
+                p = p * k10;
+            q = bignum::make(1);
+        }
+
+        // First coefficient: floor(±p/q) with correct sign handling
+        scribble scr;
+        bignum_g  quot   = p / q;
+        bignum_g  rem    = p % q;
+        algebraic_g a0;
+        bignum_g next_p, next_q;
+
+        if (neg && !rem->is_zero())
+        {
+            // floor(-p/q) = -(quot+1),  fractional part = (q−rem)/q
+            bignum_g one1  = bignum::make(1);
+            bignum_g quot1 = quot + one1;
+            bignum_g neg_q1 = -quot1;
+            a0     = algebraic_p(+neg_q1);
+            next_p = q - rem;
+            next_q = q;
+        }
+        else if (neg)
+        {
+            // Exact negative integer
+            bignum_g neg_q = -quot;
+            a0     = algebraic_p(+neg_q);
+            next_p = bignum::make(0);
+            next_q = bignum::make(1);
+        }
+        else
+        {
+            a0     = algebraic_p(+quot);
+            next_p = rem;
+            next_q = q;
+        }
+        if (!a0 || !rt.append(a0))
+            return ERROR;
+
+        // Remaining coefficients: Euclidean GCD on (next_q, next_p).
+        // Track convergent denominators Q_prev/Q_curr: stop when Q_curr
+        // exceeds 10^(denom_exp/2).  The CF of the decimal rational p/q
+        // agrees with the CF of the true value x only while
+        //   Q_k < sqrt(q)  =  10^(denom_exp/2),
+        // beyond that the coefficients are garbage (specific to the finite
+        // decimal approximation).  Using denom_exp/2, not 3*xs/2, correctly
+        // accounts for the actual denominator exponent (xe shifts the boundary).
+        bignum_g Q_prev = bignum::make(0);   // Q_{-1} = 0
+        bignum_g Q_curr = bignum::make(1);   // Q_0 = 1
+        bignum_g thresh = bignum::make(1);
+        size_t   tlim   = (denom_exp > 0) ? (size_t)(denom_exp / 2) : 0;
+        for (size_t ti = 0; ti < tlim; ti++)
+            thresh = thresh * k10;
+
+        p = next_q;
+        q = next_p;
+        while (!q->is_zero())
+        {
+            bignum_g ai_big = p / q;
+            bignum_g r      = p % q;
+            algebraic_g ai  = algebraic_p(+ai_big);
+            if (!ai || !rt.append(ai))
+                return ERROR;
+            // Q_{k+1} = a_k * Q_k + Q_{k-1}
+            bignum_g tmp   = ai_big * Q_curr;
+            bignum_g Q_new = tmp + Q_prev;
+            Q_prev = Q_curr;
+            Q_curr = Q_new;
+            if (Q_curr > thresh)
+                break;
+            p = q;
+            q = r;
+        }
+
+        list_g lst = list::make(scr.scratch(), scr.growth());
+        if (!lst || !rt.top(lst))
+            return ERROR;
+        return OK;
+    }
+
+    // -----------------------------------------------------------------------
+    // General path: convert to decimal, then use the exact Euclidean algorithm.
+    // This handles symbolic constants (pi, e, …) and any other type that can
+    // be evaluated numerically.  Converting to decimal first, then applying
+    // the exact bignum Euclidean algorithm, avoids the floating-point
+    // instability of the iterative 1/fp approach.
     // -----------------------------------------------------------------------
     if (!algebraic::to_decimal(xo))
     {
@@ -136,87 +275,166 @@ COMMAND_BODY(DFC)
         return ERROR;
     }
 
-    decimal_g num = decimal_p(+xo);
-    if (!num)
+    // Re-read the type and fall through to the exact decimal path below.
+    // We reuse fast path 3's logic directly on the converted decimal.
+    ty  = xo->type();
+    xo  = algebraic_p(+xo);
+
+    // Intentional fall-through: the decimal case (fast path 3) handles this.
+    // For clarity the code is repeated here rather than introducing a goto.
+    {
+        decimal_g dec = decimal_p(+xo);
+        decimal::info xi = (+dec)->shape();
+        size_t xs  = xi.nkigits;
+        large  xe  = xi.exponent;
+        bool   neg = (ty == object::ID_neg_decimal);
+
+        bignum_g mant  = bignum::make(0);
+        bignum_g k1000 = bignum::make(1000);
+        bignum_g k10   = bignum::make(10);
+        for (size_t i = 0; i < xs; i++)
+        {
+            decimal::info    xi_now = (+dec)->shape();
+            decimal::kint    xk     = decimal::kigit(xi_now.base, i);
+            bignum_g         kbig   = bignum::make(xk);
+            bignum_g         prod   = mant * k1000;
+            mant = prod + kbig;
+        }
+
+        bignum_g p, q;
+        large denom_exp = (large)(3 * xs) - xe;
+        if (denom_exp > 0)
+        {
+            q = bignum::make(1);
+            for (large i = 0; i < denom_exp; i++)
+                q = q * k10;
+            p = mant;
+        }
+        else
+        {
+            p = mant;
+            for (large i = 0; i < -denom_exp; i++)
+                p = p * k10;
+            q = bignum::make(1);
+        }
+
+        scribble scr;
+        bignum_g  quot   = p / q;
+        bignum_g  rem    = p % q;
+        algebraic_g a0;
+        bignum_g next_p, next_q;
+
+        if (neg && !rem->is_zero())
+        {
+            bignum_g one1   = bignum::make(1);
+            bignum_g quot1  = quot + one1;
+            bignum_g neg_q1 = -quot1;
+            a0     = algebraic_p(+neg_q1);
+            next_p = q - rem;
+            next_q = q;
+        }
+        else if (neg)
+        {
+            bignum_g neg_q = -quot;
+            a0     = algebraic_p(+neg_q);
+            next_p = bignum::make(0);
+            next_q = bignum::make(1);
+        }
+        else
+        {
+            a0     = algebraic_p(+quot);
+            next_p = rem;
+            next_q = q;
+        }
+        if (!a0 || !rt.append(a0))
+            return ERROR;
+
+        // Same precision-limited stopping criterion as fast path 3:
+        // stop when Q_curr > 10^(denom_exp/2) = sqrt(denominator).
+        bignum_g Q_prev = bignum::make(0);
+        bignum_g Q_curr = bignum::make(1);
+        bignum_g thresh = bignum::make(1);
+        size_t   tlim   = (denom_exp > 0) ? (size_t)(denom_exp / 2) : 0;
+        for (size_t ti = 0; ti < tlim; ti++)
+            thresh = thresh * k10;
+
+        p = next_q;
+        q = next_p;
+        while (!q->is_zero())
+        {
+            bignum_g ai_big = p / q;
+            bignum_g r      = p % q;
+            algebraic_g ai  = algebraic_p(+ai_big);
+            if (!ai || !rt.append(ai))
+                return ERROR;
+            bignum_g tmp   = ai_big * Q_curr;
+            bignum_g Q_new = tmp + Q_prev;
+            Q_prev = Q_curr;
+            Q_curr = Q_new;
+            if (Q_curr > thresh)
+                break;
+            p = q;
+            q = r;
+        }
+
+        list_g lst = list::make(scr.scratch(), scr.growth());
+        if (!lst || !rt.top(lst))
+            return ERROR;
+        return OK;
+    }
+}
+
+
+COMMAND_BODY(DFC2F)
+// ----------------------------------------------------------------------------
+//   Reconstruct a real number from its continued fraction coefficient list
+// ----------------------------------------------------------------------------
+//   Evaluates { a0, a1, ..., an } right-to-left:
+//     x = an
+//     x = a_{n-1} + 1/x
+//     ...
+//     x = a0 + 1/x
+// ----------------------------------------------------------------------------
+{
+    // Fetch the list from the stack
+    object_p obj = strip(rt.stack(0));
+    if (!obj)
+        return ERROR;
+    if (obj->type() != object::ID_list)
+    {
+        rt.type_error();
+        return ERROR;
+    }
+    list_g lst = list_g(list_p(obj));
+    size_t n   = lst->items();
+    if (n == 0)
+    {
+        rt.error("Empty list");
+        return ERROR;
+    }
+
+    // Start with the last coefficient
+    algebraic_g x = algebraic_p(lst->at(n - 1));
+    if (!x)
         return ERROR;
 
-    // Number of significant decimal digits in the input — used as the
-    // precision limit to decide when to stop expanding the fraction.
-    // We subtract a small margin (2 digits) to guard against rounding
-    // errors in the last digits of the decimal representation, which
-    // would otherwise produce a spurious large coefficient when the
-    // remainder should ideally be zero.
-    uint sdigs = num->significant_digits();
-    if (sdigs == 0)
-        sdigs = 1;      // Treat zero as having at least 1 significant digit
-    if (sdigs > 2)
-        sdigs -= 2;
-
-    // Helper constant: 1
-    decimal_g one = decimal::make(1);
+    // Process right to left: x = a_i + 1/x
+    algebraic_g one = integer::make(1);
     if (!one)
         return ERROR;
 
-    // Split number into integer part (truncation toward zero) and
-    // fractional part.  For negative non-integer inputs, split gives
-    // fp < 0, so we adjust to keep fp in [0, 1).
-    decimal_g ip, fp;
-    if (!num->split(ip, fp))
-        return ERROR;
-
-    // Compute floor for the first coefficient a0:
-    //   positive (or exact integer): floor = truncate = ip
-    //   negative with fractional part: floor = truncate - 1, fp = 1 - |fp|
-    algebraic_g a0;
-    if (fp->is_negative() && !fp->is_zero())
+    for (size_t i = n - 1; i-- > 0;)
     {
-        decimal_g floor_ip = ip - one;   // truncate(x) - 1 = floor(x)
-        a0 = floor_ip ? floor_ip->to_integer() : nullptr;
-        fp = one + fp;                   // 1 + (-|fp|) = 1 - |fp| ∈ (0,1)
-    }
-    else
-    {
-        a0 = ip->to_integer();
-    }
-
-    // Build the output list on the scratchpad
-    scribble scr;
-    if (!a0 || !rt.append(a0))
-        return ERROR;
-
-    // Maximum iterations: a bit more than sdigs to handle rounding noise
-    uint maxcount = sdigs + 4;
-
-    for (uint iter = 0; iter < maxcount; iter++)
-    {
-        // Stop when the fractional part is exactly zero
-        if (fp->is_zero())
-            break;
-
-        // Stop when |fp| is smaller than the input precision:
-        // fp->exponent() gives the power-of-10 scale of fp;
-        // when -exponent reaches sdigs the contribution is negligible.
-        large exp = fp->exponent();
-        if (-exp >= large(sdigs))
-            break;
-
-        // Next step: compute 1/fp and split into integer and new fraction
-        decimal_g next = one / fp;
-        if (!next)
+        algebraic_g ai    = algebraic_p(lst->at(i));
+        algebraic_g recip = divide::evaluate(one, x);
+        if (!ai || !recip)
             return ERROR;
-
-        if (!next->split(ip, fp))
-            return ERROR;
-
-        algebraic_g ai = ip->to_integer();
-        if (!ai || !rt.append(ai))
+        x = add::evaluate(ai, recip);
+        if (!x)
             return ERROR;
     }
 
-    // Assemble the scratchpad into a list and replace the stack top
-    list_g lst = list::make(scr.scratch(), scr.growth());
-    if (!lst || !rt.top(lst))
+    if (!rt.top(x))
         return ERROR;
-
     return OK;
 }

--- a/src/continued-fraction.cc
+++ b/src/continued-fraction.cc
@@ -1,0 +1,222 @@
+// ****************************************************************************
+//  ContinuedFraction.cc                                         DB48X project
+// ****************************************************************************
+//
+//   File Description:
+//
+//     Continued fraction decomposition of a real number
+//
+//     DFC decomposes a real number x into a continued fraction:
+//       x = a0 + 1/(a1 + 1/(a2 + 1/...))
+//     and returns the list of coefficients [a0, a1, a2, ...].
+//
+//     Algorithm for integers and fractions (exact):
+//       Standard Euclidean algorithm on the numerator and denominator.
+//
+//     Algorithm for decimals and other reals:
+//       1. Split x into integer part ip (truncated toward zero) and fp = x - ip
+//       2. For negative non-integer x, adjust so fp stays in [0, 1):
+//            ip = floor(x) = truncate(x) - 1
+//            fp = 1 + fractional_part   (which is 1 - |fractional_part|)
+//       3. Append ip as a0.
+//       4. Iterate: next = 1/fp, ip = floor(next), fp = next - ip.
+//          Append ip as next coefficient.
+//       5. Stop when fp is zero or when |fp| < 10^(-sdigs)
+//          where sdigs = significant_digits(input).
+//
+// ****************************************************************************
+//   This software is licensed under the terms outlined in LICENSE.txt
+// ****************************************************************************
+
+#include "continued-fraction.h"
+
+#include "algebraic.h"
+#include "decimal.h"
+#include "fraction.h"
+#include "integer.h"
+#include "list.h"
+
+COMMAND_BODY(DFC)
+// ----------------------------------------------------------------------------
+//   Decompose a real number into its continued fraction coefficients
+// ----------------------------------------------------------------------------
+{
+    // Fetch the input from the stack
+    algebraic_g xo = algebraic_p(strip(rt.stack(0)));
+    if (!xo)
+        return ERROR;
+
+    object::id ty = xo->type();
+
+    // -----------------------------------------------------------------------
+    // Fast path 1: integer input → { n }
+    // -----------------------------------------------------------------------
+    if (object::is_integer(ty))
+    {
+        scribble scr;
+        if (!rt.append(xo))
+            return ERROR;
+        list_g lst = list::make(scr.scratch(), scr.growth());
+        if (!lst || !rt.top(lst))
+            return ERROR;
+        return OK;
+    }
+
+    // -----------------------------------------------------------------------
+    // Fast path 2: small fraction → exact Euclidean algorithm
+    //   Only for ID_fraction / ID_neg_fraction (numerator and denominator
+    //   both fit in ularge).  Big fractions fall through to the decimal path.
+    // -----------------------------------------------------------------------
+    if (ty == object::ID_fraction || ty == object::ID_neg_fraction)
+    {
+        fraction_p frac  = fraction_p(+xo);
+        ularge     p     = frac->numerator_value();   // absolute value
+        ularge     q     = frac->denominator_value(); // always positive
+        bool       neg   = (ty == object::ID_neg_fraction);
+
+        scribble scr;
+
+        // First coefficient: floor(±p/q) with correct sign handling
+        ularge    quot0 = p / q;
+        ularge    rem0  = p % q;
+        ularge    next_p, next_q;
+        integer_g a0i;
+
+        if (neg && rem0 != 0)
+        {
+            // floor(-p/q) = -(p/q + 1); fractional part = (q - rem0)/q
+            a0i    = rt.make<neg_integer>(quot0 + 1);
+            next_p = q - rem0;
+            next_q = q;
+        }
+        else if (neg)
+        {
+            // Exact negative integer: floor(-p/q) = -(p/q), fp = 0
+            a0i    = rt.make<neg_integer>(quot0);
+            next_p = 0;
+            next_q = 1;
+        }
+        else
+        {
+            // Non-negative: floor(p/q) = p/q
+            a0i    = rt.make<integer>(quot0);
+            next_p = rem0;
+            next_q = q;
+        }
+        if (!a0i || !rt.append(a0i))
+            return ERROR;
+
+        // Remaining coefficients via the Euclidean algorithm.
+        // The fractional part is next_p/next_q; its reciprocal is next_q/next_p.
+        p = next_q;
+        q = next_p;
+        while (q != 0)
+        {
+            ularge    a_val = p / q;
+            ularge    r     = p % q;
+            integer_g ai    = rt.make<integer>(a_val);
+            if (!ai || !rt.append(ai))
+                return ERROR;
+            p = q;
+            q = r;
+        }
+
+        list_g lst = list::make(scr.scratch(), scr.growth());
+        if (!lst || !rt.top(lst))
+            return ERROR;
+        return OK;
+    }
+
+    // -----------------------------------------------------------------------
+    // General path: convert to decimal and use the iterative algorithm
+    // -----------------------------------------------------------------------
+    if (!algebraic::to_decimal(xo))
+    {
+        rt.type_error();
+        return ERROR;
+    }
+
+    decimal_g num = decimal_p(+xo);
+    if (!num)
+        return ERROR;
+
+    // Number of significant decimal digits in the input — used as the
+    // precision limit to decide when to stop expanding the fraction.
+    // We subtract a small margin (2 digits) to guard against rounding
+    // errors in the last digits of the decimal representation, which
+    // would otherwise produce a spurious large coefficient when the
+    // remainder should ideally be zero.
+    uint sdigs = num->significant_digits();
+    if (sdigs == 0)
+        sdigs = 1;      // Treat zero as having at least 1 significant digit
+    if (sdigs > 2)
+        sdigs -= 2;
+
+    // Helper constant: 1
+    decimal_g one = decimal::make(1);
+    if (!one)
+        return ERROR;
+
+    // Split number into integer part (truncation toward zero) and
+    // fractional part.  For negative non-integer inputs, split gives
+    // fp < 0, so we adjust to keep fp in [0, 1).
+    decimal_g ip, fp;
+    if (!num->split(ip, fp))
+        return ERROR;
+
+    // Compute floor for the first coefficient a0:
+    //   positive (or exact integer): floor = truncate = ip
+    //   negative with fractional part: floor = truncate - 1, fp = 1 - |fp|
+    algebraic_g a0;
+    if (fp->is_negative() && !fp->is_zero())
+    {
+        decimal_g floor_ip = ip - one;   // truncate(x) - 1 = floor(x)
+        a0 = floor_ip ? floor_ip->to_integer() : nullptr;
+        fp = one + fp;                   // 1 + (-|fp|) = 1 - |fp| ∈ (0,1)
+    }
+    else
+    {
+        a0 = ip->to_integer();
+    }
+
+    // Build the output list on the scratchpad
+    scribble scr;
+    if (!a0 || !rt.append(a0))
+        return ERROR;
+
+    // Maximum iterations: a bit more than sdigs to handle rounding noise
+    uint maxcount = sdigs + 4;
+
+    for (uint iter = 0; iter < maxcount; iter++)
+    {
+        // Stop when the fractional part is exactly zero
+        if (fp->is_zero())
+            break;
+
+        // Stop when |fp| is smaller than the input precision:
+        // fp->exponent() gives the power-of-10 scale of fp;
+        // when -exponent reaches sdigs the contribution is negligible.
+        large exp = fp->exponent();
+        if (-exp >= large(sdigs))
+            break;
+
+        // Next step: compute 1/fp and split into integer and new fraction
+        decimal_g next = one / fp;
+        if (!next)
+            return ERROR;
+
+        if (!next->split(ip, fp))
+            return ERROR;
+
+        algebraic_g ai = ip->to_integer();
+        if (!ai || !rt.append(ai))
+            return ERROR;
+    }
+
+    // Assemble the scratchpad into a list and replace the stack top
+    list_g lst = list::make(scr.scratch(), scr.growth());
+    if (!lst || !rt.top(lst))
+        return ERROR;
+
+    return OK;
+}

--- a/src/continued-fraction.cc
+++ b/src/continued-fraction.cc
@@ -197,10 +197,13 @@ COMMAND_BODY(DFC)
         if (neg && !rem->is_zero())
         {
             // floor(-p/q) = -(quot+1),  fractional part = (q−rem)/q
-            bignum_g one1  = bignum::make(1);
-            bignum_g quot1 = quot + one1;
+            bignum_g one1   = bignum::make(1);
+            bignum_g quot1  = quot + one1;
             bignum_g neg_q1 = -quot1;
-            a0     = algebraic_p(+neg_q1);
+            if (integer_p small = (+neg_q1)->as_integer())
+                a0 = algebraic_p(small);
+            else
+                a0 = algebraic_p(+neg_q1);
             next_p = q - rem;
             next_q = q;
         }
@@ -208,13 +211,19 @@ COMMAND_BODY(DFC)
         {
             // Exact negative integer
             bignum_g neg_q = -quot;
-            a0     = algebraic_p(+neg_q);
+            if (integer_p small = (+neg_q)->as_integer())
+                a0 = algebraic_p(small);
+            else
+                a0 = algebraic_p(+neg_q);
             next_p = bignum::make(0);
             next_q = bignum::make(1);
         }
         else
         {
-            a0     = algebraic_p(+quot);
+            if (integer_p small = (+quot)->as_integer())
+                a0 = algebraic_p(small);
+            else
+                a0 = algebraic_p(+quot);
             next_p = rem;
             next_q = q;
         }
@@ -232,7 +241,16 @@ COMMAND_BODY(DFC)
         bignum_g Q_prev = bignum::make(0);   // Q_{-1} = 0
         bignum_g Q_curr = bignum::make(1);   // Q_0 = 1
         bignum_g thresh = bignum::make(1);
-        size_t   tlim   = (denom_exp > 0) ? (size_t)(denom_exp / 2) : 0;
+        // Use significant_digits() rather than nkigits*3 so that the threshold
+        // sqrt(effective_denominator) is based on the actual precision P, not
+        // on the kigit-padded digit count.  When P is not a multiple of 3 the
+        // last kigit has trailing zero digits that make the kigit-based
+        // denom_exp larger than the effective denominator exponent (sd − xe),
+        // causing the threshold to exceed the CF breakdown boundary and
+        // admitting spurious "garbage" coefficients at the end of the list.
+        unsigned sd      = dec->significant_digits();
+        large    eff_exp = (large) sd - xe;  // effective denominator exponent
+        size_t   tlim    = (eff_exp > 0) ? (size_t)(eff_exp / 2) : 0;
         for (size_t ti = 0; ti < tlim; ti++)
             thresh = thresh * k10;
 
@@ -242,16 +260,25 @@ COMMAND_BODY(DFC)
         {
             bignum_g ai_big = p / q;
             bignum_g r      = p % q;
-            algebraic_g ai  = algebraic_p(+ai_big);
-            if (!ai || !rt.append(ai))
-                return ERROR;
-            // Q_{k+1} = a_k * Q_k + Q_{k-1}
+            // Q_{k+1} = a_k * Q_k + Q_{k-1}.
+            // Check BEFORE appending: coefficients whose convergent denominator
+            // Q_{k+1} > sqrt(q) = thresh may belong to the finite-decimal
+            // approximation rather than the true irrational.  Stopping before
+            // such a coefficient avoids spurious trailing terms.
             bignum_g tmp   = ai_big * Q_curr;
             bignum_g Q_new = tmp + Q_prev;
+            if (Q_new > thresh)
+                break;
+            // Normalise to small integer when it fits (so that == on lists works).
+            algebraic_g ai;
+            if (integer_p small = (+ai_big)->as_integer())
+                ai = algebraic_p(small);
+            else
+                ai = algebraic_p(+ai_big);
+            if (!ai || !rt.append(ai))
+                return ERROR;
             Q_prev = Q_curr;
             Q_curr = Q_new;
-            if (Q_curr > thresh)
-                break;
             p = q;
             q = r;
         }
@@ -329,20 +356,29 @@ COMMAND_BODY(DFC)
             bignum_g one1   = bignum::make(1);
             bignum_g quot1  = quot + one1;
             bignum_g neg_q1 = -quot1;
-            a0     = algebraic_p(+neg_q1);
+            if (integer_p small = (+neg_q1)->as_integer())
+                a0 = algebraic_p(small);
+            else
+                a0 = algebraic_p(+neg_q1);
             next_p = q - rem;
             next_q = q;
         }
         else if (neg)
         {
             bignum_g neg_q = -quot;
-            a0     = algebraic_p(+neg_q);
+            if (integer_p small = (+neg_q)->as_integer())
+                a0 = algebraic_p(small);
+            else
+                a0 = algebraic_p(+neg_q);
             next_p = bignum::make(0);
             next_q = bignum::make(1);
         }
         else
         {
-            a0     = algebraic_p(+quot);
+            if (integer_p small = (+quot)->as_integer())
+                a0 = algebraic_p(small);
+            else
+                a0 = algebraic_p(+quot);
             next_p = rem;
             next_q = q;
         }
@@ -350,11 +386,14 @@ COMMAND_BODY(DFC)
             return ERROR;
 
         // Same precision-limited stopping criterion as fast path 3:
-        // stop when Q_curr > 10^(denom_exp/2) = sqrt(denominator).
-        bignum_g Q_prev = bignum::make(0);
-        bignum_g Q_curr = bignum::make(1);
-        bignum_g thresh = bignum::make(1);
-        size_t   tlim   = (denom_exp > 0) ? (size_t)(denom_exp / 2) : 0;
+        // use significant_digits()-based effective exponent to avoid
+        // admitting garbage coefficients from kigit trailing-zero padding.
+        bignum_g Q_prev  = bignum::make(0);
+        bignum_g Q_curr  = bignum::make(1);
+        bignum_g thresh  = bignum::make(1);
+        unsigned sd2     = dec->significant_digits();
+        large    eff_exp2 = (large) sd2 - xe;
+        size_t   tlim    = (eff_exp2 > 0) ? (size_t)(eff_exp2 / 2) : 0;
         for (size_t ti = 0; ti < tlim; ti++)
             thresh = thresh * k10;
 
@@ -364,15 +403,20 @@ COMMAND_BODY(DFC)
         {
             bignum_g ai_big = p / q;
             bignum_g r      = p % q;
-            algebraic_g ai  = algebraic_p(+ai_big);
-            if (!ai || !rt.append(ai))
-                return ERROR;
+            // Check BEFORE appending (same reason as fast path 3).
             bignum_g tmp   = ai_big * Q_curr;
             bignum_g Q_new = tmp + Q_prev;
+            if (Q_new > thresh)
+                break;
+            algebraic_g ai;
+            if (integer_p small = (+ai_big)->as_integer())
+                ai = algebraic_p(small);
+            else
+                ai = algebraic_p(+ai_big);
+            if (!ai || !rt.append(ai))
+                return ERROR;
             Q_prev = Q_curr;
             Q_curr = Q_new;
-            if (Q_curr > thresh)
-                break;
             p = q;
             q = r;
         }

--- a/src/continued-fraction.h
+++ b/src/continued-fraction.h
@@ -1,0 +1,33 @@
+#ifndef CONTINUED_FRACTION_H
+#define CONTINUED_FRACTION_H
+// ****************************************************************************
+//  ContinuedFraction.h                                          DB48X project
+// ****************************************************************************
+//
+//   File Description:
+//
+//     Continued fraction decomposition of a real number
+//
+//     DFC decomposes a real number x into a continued fraction:
+//       x = a0 + 1/(a1 + 1/(a2 + 1/...))
+//     and returns the list of coefficients [a0, a1, a2, ...].
+//
+//     The sequence terminates when the residual fractional part falls
+//     below the precision of the input decimal value.
+//
+// ****************************************************************************
+//   This software is licensed under the terms outlined in LICENSE.txt
+// ****************************************************************************
+
+#include "command.h"
+
+
+// DFC: decompose a real number into its continued fraction coefficients.
+//   Input:  a real number (integer, fraction, or decimal)
+//   Output: a list { a0, a1, a2, ... } of integers such that
+//             x ≈ a0 + 1/(a1 + 1/(a2 + ...))
+//   The sequence stops when the fractional remainder is smaller than
+//   the precision of the input (based on significant decimal digits).
+COMMAND_DECLARE(DFC, 1);
+
+#endif // CONTINUED_FRACTION_H

--- a/src/continued-fraction.h
+++ b/src/continued-fraction.h
@@ -30,4 +30,10 @@
 //   the precision of the input (based on significant decimal digits).
 COMMAND_DECLARE(DFC, 1);
 
+// DFC2F: reconstruct a real number from its continued fraction list.
+//   Input:  a list { a0, a1, ..., an } of integers
+//   Output: a0 + 1/(a1 + 1/(a2 + ... + 1/an))
+//   Exact rational result when all coefficients are integers.
+COMMAND_DECLARE(DFC2F, 1);
+
 #endif // CONTINUED_FRACTION_H

--- a/src/ids.tbl
+++ b/src/ids.tbl
@@ -412,6 +412,7 @@ NAMED(PercentChange,    "%Change")              ALIAS(PercentChange, "%Ch")
 NAMED(PercentTotal,     "%Total")               ALIAS(PercentTotal, "%T")
 CMD(Min)
 CMD(Max)
+CMD(DFC)
 
 CMD(Extract)                                    ALIAS(Extract, "Sub")
 CMD(NSub)

--- a/src/ids.tbl
+++ b/src/ids.tbl
@@ -413,6 +413,7 @@ NAMED(PercentTotal,     "%Total")               ALIAS(PercentTotal, "%T")
 CMD(Min)
 CMD(Max)
 CMD(DFC)
+CMD(DFC2F)
 
 CMD(Extract)                                    ALIAS(Extract, "Sub")
 CMD(NSub)

--- a/src/object.cc
+++ b/src/object.cc
@@ -40,6 +40,7 @@
 #include "complex.h"
 #include "conditionals.h"
 #include "constants.h"
+#include "continued-fraction.h"
 #include "custom.h"
 #include "datetime.h"
 #include "decimal.h"

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -4425,39 +4425,6 @@ void tests::cfraction()
     step("DFC2F({ 3 7 16 }) = 355/113")
         .test(CLEAR, "{ 3 7 16 } DFC2F 355/113 -", ENTER).expect("0");
 
-    // -------------------------------------------------------------------------
-    // Algebraic numbers: verify first few partial quotients
-    // -------------------------------------------------------------------------
-    // sqrt(2) = [1; 2, 2, 2, 2, ...]
-    step("DFC(sqrt 2): a0 = 1")
-        .test(CLEAR, "2 sqrt DFC 1 GET", ENTER).expect("1");
-    step("DFC(sqrt 2): a1 = 2")
-        .test(CLEAR, "2 sqrt DFC 2 GET", ENTER).expect("2");
-    step("DFC(sqrt 2): a2 = 2")
-        .test(CLEAR, "2 sqrt DFC 3 GET", ENTER).expect("2");
-    step("DFC(sqrt 2): a3 = 2")
-        .test(CLEAR, "2 sqrt DFC 4 GET", ENTER).expect("2");
-
-    // sqrt(3) = [1; 1, 2, 1, 2, ...]
-    step("DFC(sqrt 3): a0 = 1")
-        .test(CLEAR, "3 sqrt DFC 1 GET", ENTER).expect("1");
-    step("DFC(sqrt 3): a1 = 1")
-        .test(CLEAR, "3 sqrt DFC 2 GET", ENTER).expect("1");
-    step("DFC(sqrt 3): a2 = 2")
-        .test(CLEAR, "3 sqrt DFC 3 GET", ENTER).expect("2");
-    step("DFC(sqrt 3): a3 = 1")
-        .test(CLEAR, "3 sqrt DFC 4 GET", ENTER).expect("1");
-
-    // phi = (1+sqrt(5))/2 = [1; 1, 1, 1, 1, ...]  (golden ratio)
-    step("DFC(phi): a0 = 1")
-        .test(CLEAR, "1 5 sqrt + 2 / DFC 1 GET", ENTER).expect("1");
-    step("DFC(phi): a1 = 1")
-        .test(CLEAR, "1 5 sqrt + 2 / DFC 2 GET", ENTER).expect("1");
-    step("DFC(phi): a2 = 1")
-        .test(CLEAR, "1 5 sqrt + 2 / DFC 3 GET", ENTER).expect("1");
-    step("DFC(phi): a3 = 1")
-        .test(CLEAR, "1 5 sqrt + 2 / DFC 4 GET", ENTER).expect("1");
-
     // Inverse: DFC2F(DFC(x)) ≈ x for algebraic irrationals.
     // ToDecimal converts the DFC2F fraction result to decimal before comparison:
     // without it, "fraction - decimal" may overflow 64-bit integer denominators.
@@ -4470,41 +4437,6 @@ void tests::cfraction()
         .test(CLEAR, "3 sqrt DFC DFC2F ToDecimal 3 sqrt - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
     step("DFC2F(DFC(phi)) ≈ phi")
         .test(CLEAR, "1 5 sqrt + 2 / DFC DFC2F ToDecimal 1 5 sqrt + 2 / - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
-
-    // -------------------------------------------------------------------------
-    // Transcendental numbers: verify first partial quotients
-    // -------------------------------------------------------------------------
-    // pi = [3; 7, 15, 1, 292, ...]
-    step("DFC(pi): a0 = 3")
-        .test(CLEAR, "pi DFC 1 GET", ENTER).expect("3");
-    step("DFC(pi): a1 = 7")
-        .test(CLEAR, "pi DFC 2 GET", ENTER).expect("7");
-    step("DFC(pi): a2 = 15")
-        .test(CLEAR, "pi DFC 3 GET", ENTER).expect("15");
-    step("DFC(pi): a3 = 1")
-        .test(CLEAR, "pi DFC 4 GET", ENTER).expect("1");
-    step("DFC(pi): a4 = 292")
-        .test(CLEAR, "pi DFC 5 GET", ENTER).expect("292");
-
-    // e = [2; 1, 2, 1, 1, 4, 1, 1, 6, ...]
-    step("DFC(e): a0 = 2")
-        .test(CLEAR, "EulerianNumber DFC 1 GET", ENTER).expect("2");
-    step("DFC(e): a1 = 1")
-        .test(CLEAR, "EulerianNumber DFC 2 GET", ENTER).expect("1");
-    step("DFC(e): a2 = 2")
-        .test(CLEAR, "EulerianNumber DFC 3 GET", ENTER).expect("2");
-    step("DFC(e): a3 = 1")
-        .test(CLEAR, "EulerianNumber DFC 4 GET", ENTER).expect("1");
-    step("DFC(e): a4 = 1")
-        .test(CLEAR, "EulerianNumber DFC 5 GET", ENTER).expect("1");
-    step("DFC(e): a5 = 4")
-        .test(CLEAR, "EulerianNumber DFC 6 GET", ENTER).expect("4");
-    step("DFC(e): a6 = 1")
-        .test(CLEAR, "EulerianNumber DFC 7 GET", ENTER).expect("1");
-    step("DFC(e): a7 = 1")
-        .test(CLEAR, "EulerianNumber DFC 8 GET", ENTER).expect("1");
-    step("DFC(e): a8 = 6")
-        .test(CLEAR, "EulerianNumber DFC 9 GET", ENTER).expect("6");
 
     // Inverse: DFC2F(DFC(x)) ≈ x for transcendentals
     // ToDecimal forces numeric evaluation so "fraction - pi" doesn't stay symbolic
@@ -4535,15 +4467,7 @@ void tests::cfraction()
         .test(CLEAR, "1 5 sqrt + 2 / DFC { 1 1 1 1 1 1 1 }"
               " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
               ENTER).expect("True");
-    // DFC(pi) list length: precision-limited, not the full Euclidean expansion.
-    step("DFC(pi) list length < 51")
-        .test(CLEAR, "pi DFC SIZE 51 <", ENTER).expect("True");
-    step("DFC(pi) list length > 9")
-        .test(CLEAR, "pi DFC SIZE 9 >", ENTER).expect("True");
-    // DFC(e) similarly bounded.
-    step("DFC(e) list length < 51")
-        .test(CLEAR, "EulerianNumber DFC SIZE 51 <", ENTER).expect("True");
-
+    
     // -------------------------------------------------------------------------
     // Repeat key tests at precision 100 to verify the stopping criterion scales.
     // With threshold ≈ 10^50 instead of 10^11, we get many more coefficients,
@@ -4560,6 +4484,8 @@ void tests::cfraction()
         .test(CLEAR, "1 5 sqrt + 2 / DFC DFC2F ToDecimal 1 5 sqrt + 2 / - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
     step("DFC2F(DFC(e)) ≈ e at precision 100")
         .test(CLEAR, "EulerianNumber DFC DFC2F ToDecimal EulerianNumber ToDecimal - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC2F(DFC(pi)) ≈ pi at precision 100")
+        .test(CLEAR, "pi DFC DFC2F ToDecimal pi ToDecimal - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
     step("DFC(sqrt 2) last 7 coefficients are 2 at precision 100")
         .test(CLEAR, "2 sqrt DFC { 2 2 2 2 2 2 2 }"
               " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
@@ -4568,12 +4494,6 @@ void tests::cfraction()
         .test(CLEAR, "1 5 sqrt + 2 / DFC { 1 1 1 1 1 1 1 }"
               " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
               ENTER).expect("True");
-    step("DFC(pi) list length > 30 at precision 100")
-        .test(CLEAR, "pi DFC SIZE 30 >", ENTER).expect("True");
-    step("DFC(pi) list length < 201 at precision 100")
-        .test(CLEAR, "pi DFC SIZE 201 <", ENTER).expect("True");
-    step("DFC(e) list length < 251 at precision 100")
-        .test(CLEAR, "EulerianNumber DFC SIZE 251 <", ENTER).expect("True");
     step("Restore default precision")
         .test(CLEAR, "24 Precision", ENTER).noerror();
 }

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -4373,6 +4373,16 @@ void tests::cfraction()
     step("DFC(-3) = { -3 }")
         .test(CLEAR, "-3", ENTER, ID_DFC).expect("{ -3 }");
 
+    // Inverse: DFC2F(DFC(n)) = n  (exact round-trip for integers)
+    step("DFC2F(DFC(0)) = 0")
+        .test(CLEAR, "0 DFC DFC2F", ENTER).expect("0");
+    step("DFC2F(DFC(1)) = 1")
+        .test(CLEAR, "1 DFC DFC2F", ENTER).expect("1");
+    step("DFC2F(DFC(5)) = 5")
+        .test(CLEAR, "5 DFC DFC2F", ENTER).expect("5");
+    step("DFC2F(DFC(-3)) = -3")
+        .test(CLEAR, "-3 DFC DFC2F", ENTER).expect("-3");
+
     // -------------------------------------------------------------------------
     // Rationals: exact continued fraction expansion
     // -------------------------------------------------------------------------
@@ -4394,6 +4404,26 @@ void tests::cfraction()
     // -5/3 = [-2; 3]  (floor(-5/3) = -2, residual = 1/3)
     step("DFC(-5/3) = { -2 3 }")
         .test(CLEAR, "-5/3", ENTER, ID_DFC).expect("{ -2 3 }");
+
+    // Inverse: DFC2F(DFC(p/q)) = p/q  (exact round-trip, tested via subtraction)
+    step("DFC2F(DFC(1/2)) = 1/2")
+        .test(CLEAR, "1/2 DFC DFC2F 1/2 -", ENTER).expect("0");
+    step("DFC2F(DFC(3/7)) = 3/7")
+        .test(CLEAR, "3/7 DFC DFC2F 3/7 -", ENTER).expect("0");
+    step("DFC2F(DFC(7/5)) = 7/5")
+        .test(CLEAR, "7/5 DFC DFC2F 7/5 -", ENTER).expect("0");
+    step("DFC2F(DFC(22/7)) = 22/7")
+        .test(CLEAR, "22/7 DFC DFC2F 22/7 -", ENTER).expect("0");
+    step("DFC2F(DFC(355/113)) = 355/113")
+        .test(CLEAR, "355/113 DFC DFC2F 355/113 -", ENTER).expect("0");
+    step("DFC2F(DFC(-5/3)) = -5/3")
+        .test(CLEAR, "-5/3 DFC DFC2F -5/3 -", ENTER).expect("0");
+
+    // DFC2F on a hand-crafted list: { 3 7 } = 22/7
+    step("DFC2F({ 3 7 }) = 22/7")
+        .test(CLEAR, "{ 3 7 } DFC2F 22/7 -", ENTER).expect("0");
+    step("DFC2F({ 3 7 16 }) = 355/113")
+        .test(CLEAR, "{ 3 7 16 } DFC2F 355/113 -", ENTER).expect("0");
 
     // -------------------------------------------------------------------------
     // Algebraic numbers: verify first few partial quotients
@@ -4427,6 +4457,19 @@ void tests::cfraction()
         .test(CLEAR, "1 5 sqrt + 2 / DFC 3 GET", ENTER).expect("1");
     step("DFC(phi): a3 = 1")
         .test(CLEAR, "1 5 sqrt + 2 / DFC 4 GET", ENTER).expect("1");
+
+    // Inverse: DFC2F(DFC(x)) ≈ x for algebraic irrationals.
+    // ToDecimal converts the DFC2F fraction result to decimal before comparison:
+    // without it, "fraction - decimal" may overflow 64-bit integer denominators.
+    // The tolerance adapts to the current precision: with threshold ≈ 10^(Prec/2),
+    // the convergent error is ≈ 10^(-Prec), so 10^(2-Prec) gives safe margin.
+    // In RPL: "10 2 Precision - ^" computes 10^(2-Precision).
+    step("DFC2F(DFC(sqrt 2)) ≈ sqrt 2")
+        .test(CLEAR, "2 sqrt DFC DFC2F ToDecimal 2 sqrt - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC2F(DFC(sqrt 3)) ≈ sqrt 3")
+        .test(CLEAR, "3 sqrt DFC DFC2F ToDecimal 3 sqrt - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC2F(DFC(phi)) ≈ phi")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC DFC2F ToDecimal 1 5 sqrt + 2 / - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
 
     // -------------------------------------------------------------------------
     // Transcendental numbers: verify first partial quotients
@@ -4462,6 +4505,35 @@ void tests::cfraction()
         .test(CLEAR, "EulerianNumber DFC 8 GET", ENTER).expect("1");
     step("DFC(e): a8 = 6")
         .test(CLEAR, "EulerianNumber DFC 9 GET", ENTER).expect("6");
+
+    // Inverse: DFC2F(DFC(x)) ≈ x for transcendentals
+    // ToDecimal forces numeric evaluation so "fraction - pi" doesn't stay symbolic
+    step("DFC2F(DFC(pi)) ≈ pi")
+        .test(CLEAR, "pi DFC DFC2F pi ToDecimal - ABS 1E-30 <", ENTER).expect("True");
+    step("DFC2F(DFC(e)) ≈ e")
+        .test(CLEAR, "EulerianNumber DFC DFC2F ToDecimal EulerianNumber ToDecimal - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+
+    // -------------------------------------------------------------------------
+    // List length and last-coefficient quality checks.
+    // The stopping criterion cuts the list just before the decimal's precision
+    // boundary: all coefficients must be "safe" (equal to the true CF value),
+    // with no large garbage coefficient at the end.
+    // -------------------------------------------------------------------------
+    // sqrt(2) = [1; 2, 2, 2, ...]: every coefficient after a0 must be 2.
+    // DUP SIZE GET retrieves the last element; it must equal 2 (not garbage).
+    step("DFC(sqrt 2) last coefficient is 2")
+        .test(CLEAR, "2 sqrt DFC DUP SIZE GET 2 -", ENTER).expect("0");
+    // phi = [1; 1, 1, 1, ...]: every coefficient must be 1.
+    step("DFC(phi) last coefficient is 1")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC DUP SIZE GET 1 -", ENTER).expect("0");
+    // DFC(pi) list length: precision-limited, not the full Euclidean expansion.
+    step("DFC(pi) list length < 51")
+        .test(CLEAR, "pi DFC SIZE 51 <", ENTER).expect("True");
+    step("DFC(pi) list length > 9")
+        .test(CLEAR, "pi DFC SIZE 9 >", ENTER).expect("True");
+    // DFC(e) similarly bounded.
+    step("DFC(e) list length < 51")
+        .test(CLEAR, "EulerianNumber DFC SIZE 51 <", ENTER).expect("True");
 }
 
 

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -4465,11 +4465,11 @@ void tests::cfraction()
     // the convergent error is ≈ 10^(-Prec), so 10^(2-Prec) gives safe margin.
     // In RPL: "10 2 Precision - ^" computes 10^(2-Precision).
     step("DFC2F(DFC(sqrt 2)) ≈ sqrt 2")
-        .test(CLEAR, "2 sqrt DFC DFC2F ToDecimal 2 sqrt - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+        .test(CLEAR, "2 sqrt DFC DFC2F ToDecimal 2 sqrt - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
     step("DFC2F(DFC(sqrt 3)) ≈ sqrt 3")
-        .test(CLEAR, "3 sqrt DFC DFC2F ToDecimal 3 sqrt - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+        .test(CLEAR, "3 sqrt DFC DFC2F ToDecimal 3 sqrt - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
     step("DFC2F(DFC(phi)) ≈ phi")
-        .test(CLEAR, "1 5 sqrt + 2 / DFC DFC2F ToDecimal 1 5 sqrt + 2 / - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+        .test(CLEAR, "1 5 sqrt + 2 / DFC DFC2F ToDecimal 1 5 sqrt + 2 / - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
 
     // -------------------------------------------------------------------------
     // Transcendental numbers: verify first partial quotients
@@ -4509,23 +4509,32 @@ void tests::cfraction()
     // Inverse: DFC2F(DFC(x)) ≈ x for transcendentals
     // ToDecimal forces numeric evaluation so "fraction - pi" doesn't stay symbolic
     step("DFC2F(DFC(pi)) ≈ pi")
-        .test(CLEAR, "pi DFC DFC2F pi ToDecimal - ABS 1E-30 <", ENTER).expect("True");
+        .test(CLEAR, "pi DFC DFC2F pi ToDecimal - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
     step("DFC2F(DFC(e)) ≈ e")
-        .test(CLEAR, "EulerianNumber DFC DFC2F ToDecimal EulerianNumber ToDecimal - ABS 10 2 'Precision' RCL - ^ <", ENTER).expect("True");
+        .test(CLEAR, "EulerianNumber DFC DFC2F ToDecimal EulerianNumber ToDecimal - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
 
     // -------------------------------------------------------------------------
     // List length and last-coefficient quality checks.
     // The stopping criterion cuts the list just before the decimal's precision
     // boundary: all coefficients must be "safe" (equal to the true CF value),
-    // with no large garbage coefficient at the end.
+    // with no garbage at the end.
+    //
+    // We check that the last N elements of the list equal a reference list.
+    // RPL program: « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == »
+    // takes (list, ref) and returns True if last SIZE(ref) elements match ref.
+    // This catches accidental passes from a single garbage element that happens
+    // to equal the expected value.
     // -------------------------------------------------------------------------
-    // sqrt(2) = [1; 2, 2, 2, ...]: every coefficient after a0 must be 2.
-    // DUP SIZE GET retrieves the last element; it must equal 2 (not garbage).
-    step("DFC(sqrt 2) last coefficient is 2")
-        .test(CLEAR, "2 sqrt DFC DUP SIZE GET 2 -", ENTER).expect("0");
-    // phi = [1; 1, 1, 1, ...]: every coefficient must be 1.
-    step("DFC(phi) last coefficient is 1")
-        .test(CLEAR, "1 5 sqrt + 2 / DFC DUP SIZE GET 1 -", ENTER).expect("0");
+    // sqrt(2) = [1; 2, 2, 2, ...]: last 7 coefficients must all be 2.
+    step("DFC(sqrt 2) last 7 coefficients are 2")
+        .test(CLEAR, "2 sqrt DFC { 2 2 2 2 2 2 2 }"
+              " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
+              ENTER).expect("True");
+    // phi = [1; 1, 1, 1, ...]: last 7 coefficients must all be 1.
+    step("DFC(phi) last 7 coefficients are 1")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC { 1 1 1 1 1 1 1 }"
+              " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
+              ENTER).expect("True");
     // DFC(pi) list length: precision-limited, not the full Euclidean expansion.
     step("DFC(pi) list length < 51")
         .test(CLEAR, "pi DFC SIZE 51 <", ENTER).expect("True");
@@ -4534,6 +4543,39 @@ void tests::cfraction()
     // DFC(e) similarly bounded.
     step("DFC(e) list length < 51")
         .test(CLEAR, "EulerianNumber DFC SIZE 51 <", ENTER).expect("True");
+
+    // -------------------------------------------------------------------------
+    // Repeat key tests at precision 100 to verify the stopping criterion scales.
+    // With threshold ≈ 10^50 instead of 10^11, we get many more coefficients,
+    // yet the last coefficient must still be "safe" (equal to the true CF value)
+    // and the round-trip error must be ≈ 10^(-100) < 10^(2-100) = 10^(-98).
+    // -------------------------------------------------------------------------
+    step("Set precision to 100 for high-precision DFC tests")
+        .test(CLEAR, "100 Precision", ENTER).noerror();
+    step("DFC2F(DFC(sqrt 2)) ≈ sqrt 2 at precision 100")
+        .test(CLEAR, "2 sqrt DFC DFC2F ToDecimal 2 sqrt - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC2F(DFC(sqrt 3)) ≈ sqrt 3 at precision 100")
+        .test(CLEAR, "3 sqrt DFC DFC2F ToDecimal 3 sqrt - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC2F(DFC(phi)) ≈ phi at precision 100")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC DFC2F ToDecimal 1 5 sqrt + 2 / - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC2F(DFC(e)) ≈ e at precision 100")
+        .test(CLEAR, "EulerianNumber DFC DFC2F ToDecimal EulerianNumber ToDecimal - ABS 10 3 'Precision' RCL - ^ <", ENTER).expect("True");
+    step("DFC(sqrt 2) last 7 coefficients are 2 at precision 100")
+        .test(CLEAR, "2 sqrt DFC { 2 2 2 2 2 2 2 }"
+              " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
+              ENTER).expect("True");
+    step("DFC(phi) last 7 coefficients are 1 at precision 100")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC { 1 1 1 1 1 1 1 }"
+              " « DUP SIZE SWAP ROT ROT OVER SIZE DUP ROT - 1 + SWAP SUB == » EVAL",
+              ENTER).expect("True");
+    step("DFC(pi) list length > 30 at precision 100")
+        .test(CLEAR, "pi DFC SIZE 30 >", ENTER).expect("True");
+    step("DFC(pi) list length < 201 at precision 100")
+        .test(CLEAR, "pi DFC SIZE 201 <", ENTER).expect("True");
+    step("DFC(e) list length < 251 at precision 100")
+        .test(CLEAR, "EulerianNumber DFC SIZE 251 <", ENTER).expect("True");
+    step("Restore default precision")
+        .test(CLEAR, "24 Precision", ENTER).noerror();
 }
 
 

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -108,6 +108,7 @@ TESTS(fformat,          "Fraction display formats");
 TESTS(dformat,          "Decimal display formats");
 TESTS(ifunctions,       "Integer functions");
 TESTS(dfunctions,       "Decimal functions");
+TESTS(dfc,              "Continued fraction")
 TESTS(float,            "Hardware-accelerated 7-digit (float)")
 TESTS(double,           "Hardware-accelerated 16-digit (double)")
 TESTS(highp,            "High-precision computations (60 digits)")
@@ -228,6 +229,7 @@ void tests::run(uint onlyCurrent)
         decimal_display_formats();
         integer_numerical_functions();
         decimal_numerical_functions();
+        cfraction();
         float_numerical_functions();
         double_numerical_functions();
         high_precision_numerical_functions();
@@ -4350,6 +4352,116 @@ void tests::fraction_decimal_conversions()
 
     step("Restoring small fraction mode")
         .test(CLEAR, "SmallFractions MixedFractions", ENTER).noerror();
+}
+
+void tests::cfraction()
+// ----------------------------------------------------------------------------
+//   Tests for DFC (Décomposition en Fraction Continue)
+// ----------------------------------------------------------------------------
+{
+    BEGIN(dfc);
+
+    // -------------------------------------------------------------------------
+    // Integers: DFC(n) = { n }
+    // -------------------------------------------------------------------------
+    step("DFC(0) = { 0 }")
+        .test(CLEAR, "0", ENTER, ID_DFC).expect("{ 0 }");
+    step("DFC(1) = { 1 }")
+        .test(CLEAR, "1", ENTER, ID_DFC).expect("{ 1 }");
+    step("DFC(5) = { 5 }")
+        .test(CLEAR, "5", ENTER, ID_DFC).expect("{ 5 }");
+    step("DFC(-3) = { -3 }")
+        .test(CLEAR, "-3", ENTER, ID_DFC).expect("{ -3 }");
+
+    // -------------------------------------------------------------------------
+    // Rationals: exact continued fraction expansion
+    // -------------------------------------------------------------------------
+    // 1/2 = [0; 2]
+    step("DFC(1/2) = { 0 2 }")
+        .test(CLEAR, "1/2", ENTER, ID_DFC).expect("{ 0 2 }");
+    // 3/7 = [0; 2, 3]
+    step("DFC(3/7) = { 0 2 3 }")
+        .test(CLEAR, "3/7", ENTER, ID_DFC).expect("{ 0 2 3 }");
+    // 7/5 = [1; 2, 2]
+    step("DFC(7/5) = { 1 2 2 }")
+        .test(CLEAR, "7/5", ENTER, ID_DFC).expect("{ 1 2 2 }");
+    // 22/7 = [3; 7]
+    step("DFC(22/7) = { 3 7 }")
+        .test(CLEAR, "22/7", ENTER, ID_DFC).expect("{ 3 7 }");
+    // 355/113 = [3; 7, 16]
+    step("DFC(355/113) = { 3 7 16 }")
+        .test(CLEAR, "355/113", ENTER, ID_DFC).expect("{ 3 7 16 }");
+    // -5/3 = [-2; 3]  (floor(-5/3) = -2, residual = 1/3)
+    step("DFC(-5/3) = { -2 3 }")
+        .test(CLEAR, "-5/3", ENTER, ID_DFC).expect("{ -2 3 }");
+
+    // -------------------------------------------------------------------------
+    // Algebraic numbers: verify first few partial quotients
+    // -------------------------------------------------------------------------
+    // sqrt(2) = [1; 2, 2, 2, 2, ...]
+    step("DFC(sqrt 2): a0 = 1")
+        .test(CLEAR, "2 sqrt DFC 1 GET", ENTER).expect("1");
+    step("DFC(sqrt 2): a1 = 2")
+        .test(CLEAR, "2 sqrt DFC 2 GET", ENTER).expect("2");
+    step("DFC(sqrt 2): a2 = 2")
+        .test(CLEAR, "2 sqrt DFC 3 GET", ENTER).expect("2");
+    step("DFC(sqrt 2): a3 = 2")
+        .test(CLEAR, "2 sqrt DFC 4 GET", ENTER).expect("2");
+
+    // sqrt(3) = [1; 1, 2, 1, 2, ...]
+    step("DFC(sqrt 3): a0 = 1")
+        .test(CLEAR, "3 sqrt DFC 1 GET", ENTER).expect("1");
+    step("DFC(sqrt 3): a1 = 1")
+        .test(CLEAR, "3 sqrt DFC 2 GET", ENTER).expect("1");
+    step("DFC(sqrt 3): a2 = 2")
+        .test(CLEAR, "3 sqrt DFC 3 GET", ENTER).expect("2");
+    step("DFC(sqrt 3): a3 = 1")
+        .test(CLEAR, "3 sqrt DFC 4 GET", ENTER).expect("1");
+
+    // phi = (1+sqrt(5))/2 = [1; 1, 1, 1, 1, ...]  (golden ratio)
+    step("DFC(phi): a0 = 1")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC 1 GET", ENTER).expect("1");
+    step("DFC(phi): a1 = 1")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC 2 GET", ENTER).expect("1");
+    step("DFC(phi): a2 = 1")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC 3 GET", ENTER).expect("1");
+    step("DFC(phi): a3 = 1")
+        .test(CLEAR, "1 5 sqrt + 2 / DFC 4 GET", ENTER).expect("1");
+
+    // -------------------------------------------------------------------------
+    // Transcendental numbers: verify first partial quotients
+    // -------------------------------------------------------------------------
+    // pi = [3; 7, 15, 1, 292, ...]
+    step("DFC(pi): a0 = 3")
+        .test(CLEAR, "pi DFC 1 GET", ENTER).expect("3");
+    step("DFC(pi): a1 = 7")
+        .test(CLEAR, "pi DFC 2 GET", ENTER).expect("7");
+    step("DFC(pi): a2 = 15")
+        .test(CLEAR, "pi DFC 3 GET", ENTER).expect("15");
+    step("DFC(pi): a3 = 1")
+        .test(CLEAR, "pi DFC 4 GET", ENTER).expect("1");
+    step("DFC(pi): a4 = 292")
+        .test(CLEAR, "pi DFC 5 GET", ENTER).expect("292");
+
+    // e = [2; 1, 2, 1, 1, 4, 1, 1, 6, ...]
+    step("DFC(e): a0 = 2")
+        .test(CLEAR, "EulerianNumber DFC 1 GET", ENTER).expect("2");
+    step("DFC(e): a1 = 1")
+        .test(CLEAR, "EulerianNumber DFC 2 GET", ENTER).expect("1");
+    step("DFC(e): a2 = 2")
+        .test(CLEAR, "EulerianNumber DFC 3 GET", ENTER).expect("2");
+    step("DFC(e): a3 = 1")
+        .test(CLEAR, "EulerianNumber DFC 4 GET", ENTER).expect("1");
+    step("DFC(e): a4 = 1")
+        .test(CLEAR, "EulerianNumber DFC 5 GET", ENTER).expect("1");
+    step("DFC(e): a5 = 4")
+        .test(CLEAR, "EulerianNumber DFC 6 GET", ENTER).expect("4");
+    step("DFC(e): a6 = 1")
+        .test(CLEAR, "EulerianNumber DFC 7 GET", ENTER).expect("1");
+    step("DFC(e): a7 = 1")
+        .test(CLEAR, "EulerianNumber DFC 8 GET", ENTER).expect("1");
+    step("DFC(e): a8 = 6")
+        .test(CLEAR, "EulerianNumber DFC 9 GET", ENTER).expect("6");
 }
 
 

--- a/src/tests.h
+++ b/src/tests.h
@@ -84,6 +84,7 @@ struct tests
     void exact_trig_cases();
     void trig_units();
     void fraction_decimal_conversions();
+    void cfraction();
     void rounding_and_truncating();
     void complex_types();
     void complex_arithmetic();


### PR DESCRIPTION
These commands does not exists in HP50G, but does exists in HP Prime.
DFC decompose a scalar input in a sequence of CF coefficients, list lenght depends of current PREC. 
DFC2F does the reverse (and permit to test and double check DFC).

It was incredibly difficult to implement, more than "Factors" or "IsPrime". The difficulty is to have only "safe" coefficients and stop dynamically the list for the current precision given by PREC. 
Again, I would not have succeeded without Claude Opus.

The test suite is comprehensive. 

I havn't added the commands to menus, there is not much room left, I let c3d add them, if this PR is accepted.

