### PR TITLE
Fixes #1593: DB48X keyboard not visible on Samsung Galaxy S23 Ultra

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ This software was brought to you by the DB48X authors below
 - Jerome Ibanes <jibanes@gmail.com> (Dockerfile)
 - Jesus Cano <jcanovel@gmail.com>
 - Riccardo Lucatuorto <gnuduncan@gmail.com>
+- Ralf Ahlbrink <raprism@users.noreply.github.com>
 
 Copyright (c) 2022-2025, the DB48X authors
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ This software was brought to you by the DB48X authors below
 - Ed van Gasteren <Ed@vanGasteren.net> (Bug fixes)
 - Jerome Ibanes <jibanes@gmail.com> (Dockerfile)
 - Jesus Cano <jcanovel@gmail.com>
+- Riccardo Lucatuorto <gnuduncan@gmail.com>
 
 Copyright (c) 2022-2025, the DB48X authors
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ This software was brought to you by the DB48X authors below
 - Thomas Eberhardt <sneakywumpus@gmail.com> (Bug fixes)
 - Ed van Gasteren <Ed@vanGasteren.net> (Bug fixes)
 - Jerome Ibanes <jibanes@gmail.com> (Dockerfile)
+- Jesus Cano <jcanovel@gmail.com>
 
 Copyright (c) 2022-2025, the DB48X authors
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,7 @@
 # Building the DB48X project
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/c3d/db48x)
+
 The DB48X project can be built in two variants:
 
 * A simulator that uses Qt to approximately simulate the DM42 platform. There is

--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -1,0 +1,142 @@
+# Using the simulator
+
+The DB48X project comes with a simulator.
+It brings calculator functionality to your computer (Linux, macOS, Windows + WSL + Fedora).
+
+This document describes some of its additional functionality.
+Building the simulator is described in [BUILD](BUILD.md).
+
+Run the simulator with the command `<path>/sim/db48x [Option]* [argument]*`.
+The simulator uses a few [Environment variables](#environment-variables), and its behavior can be further
+influenced with [Options](#options) and/or [Arguments](#arguments).
+
+The simulator uses the [recorder](https://github.com/c3d/recorder) subsystem to [trace](#tracing) what is happening under the hood.
+
+
+## Environment variables
+
+| Variable | Description |
+| --- | --- |
+| DB48X_TRACES | A trace filter value for the recorder. Default = ".*(error\|warn(ing)?)s?" |
+| DB48X_INSTALL | Setting this variable is equivalent to setting the `-I` option. |
+
+
+## Options
+
+The simulator can be started with the command-line options listed in the table below.
+
+| Option | Description |
+| --- | --- |
+| -d[[`<whitespace>`]`<integer>`] | Set key delay time in milliseconds to slow down tests. Default = 0ms. |
+| -i[[`<whitespace>`]`<integer>`] | Set the maximum time waiting for an image to match the expected image during testing. Default is 500ms. |
+| -k[[`<whitespace>`]`<argument>`] | Load a saved keymap to change keyboard layout. |
+| -m[[`<whitespace>`]`<integer>`] | Set the memory size available to the calculator in megabytes. |
+| -n | Enable beeps while running the test suite (noisy testing). |
+| -r[[`<whitespace>`]`<integer>`] | Set the time to wait for a screen update in milliseconds. Default = 20ms. |
+| -s[[`<whitespace>`]`<real>`] | Scale the application window by the given floating-point scaling factor. |
+| -t`<trace>` | Enable the named recorder trace. Multiple traces can be enabled by using multiple `-t` options, or by using a regular expression as an argument to `-t`. |
+| -w[[`<whitespace>`]`<integer>`] | Set the default time the test suite waits for a command to complete, in milliseconds. You can increase this to run the test suite on a very slow machine. The default is 1000ms. |
+| -D[[`<whitespace>`]`<argument>`] | Set the pattern of recorder traces to show when a test fails. |
+| -I | Initialize the user's environment. WARNING: This may overwrite user configuration with defaults. |
+| -N | Disable beeps. Use this if you get error messages about audio drivers. |
+| -T[`<test>` \| all] | Run tests. Without a suffix, run the full test suite. With a suffix, select individual test suites. For example `-Tmatrices` will run the `matrices` portion of the test suite. |
+| -O[`<test>` \| all] | Only configure test-suite recorder traces (`est_<test>` or `est_.*` for `all`) without enabling automatic test execution. |
+
+
+## Arguments
+
+Command-line arguments that do not represent simulator options set the initial value for an RPL setting or flag.
+
+Settings are specified as `<argument>=<value>`.
+Values "yes" or "true" (case insensitive) are interpreted as true.
+Values of the form `<positive integer>` are interpreted as such.
+
+A few examples:
+
+* `DecimalDot=false ShowMonthName=true` will start with a decimal comma separator and show the month name in the header.
+* `AngleMode=1` will start the simulator in Radians mode.
+
+Use the `Modes` command in the application to check the effect.
+
+Note that this only sets the _default_ settings for the simulator, which can then be overridden by any state file being loaded.
+
+
+## Computer keyboard
+
+You can click the calculator buttons with the mouse, as well as use the keyboard to control operations.
+
+### Calculator keys
+
+The majority of the keys map directly to calculator keys.
+
+| Key(s) | DB48X button / Description |
+| --- | --- |
+| digit | _digit_ |
+| . + - * / | _._ _+_ _-_ _×_ (multiply) _÷_ (divide) |
+| Backspace | ← |
+| Enter | _ENTER_ |
+| Tab | Shift (yellow) key |
+| Up Down Left Right | ◀ ▶︎ ◀︎ ▶︎ (the DM42/DM32 only have left and right keys) |
+| Esc | _EXIT_ |
+| Space | _=_ (also serves as the space or `RUN` key depending on context) |
+| F1-F6 | Simulates DM42 / DM32 softmenu keys from left to right |
+| A-Z | Corresponding key on calculator, e.g. _J_ maps to `SIN` |
+
+### Alpha modes
+
+Alphabetic keys map directly to the corresponding calculator key. To cycle through alpha modes, use Tab + Enter in the same way you would use Shift + Enter on the physical device.
+
+In addition, the simulator emulates _transient alpha_ mode using Shift or Alt:
+
+| Shift + Alpha | Uppercase Alpha |
+| Alt + Alpha | Lowercase Alpha |
+
+For example, you can quickly type `Hello` by holding Shift-H, followed by Alt-e-l-l-o. You can use this to enter names or commands.
+
+### Simulator-specific commands
+
+Some keyboard shortcuts are specific to the simulator.
+
+| Ctrl + C | Copy the top of the stack or edit line to the clipboard. |
+| Ctrl + Shift + C | Copy the screen contents to the clipboard |
+| Ctrl + V | Paste the clipboard to the edit line. |
+| F8 | Save program (`SAVE_PGM`) |
+| F9 | Take a screenshot snapshot (saved in `screens/`) |
+| F10 | Load another keyboard map. Cycle through db48x, legacy, 42style, and true42. |
+| F11 | Run / Interrupt the current test. |
+| F12 | Run / Interrupt the test suite. |
+| F13 | Run / Interrupt demo 1 |
+| F14 | Run / Interrupt demo 2 |
+| F15 | Run / Interrupt demo 3 |
+| F16 | Dump the flight recorder |
+
+
+## Initialize the user's environment
+
+A set of directories (`/help, /library, /state, /config`) and the files in them
+are copied by the `-I` option to an application-specific location, which then holds the virtual filesystem for the calculator:
+
+* `~/.local/share/DB48X/DB48X/` on Linux or Windows + WSL
+* `./Library/Application Support/DB48X/DB48X` on macOS
+
+The simulator works with the files in these locations.
+
+
+## Run / interrupt the test suite
+
+There is a comprehensive test suite integrated in the simulator, which you can run with the F12 key, or by launching the simulator with the `-Tall` option.
+
+If you make changes, run the test suite to verify you did not break existing functionality. If you add a feature, add tests for it.
+
+
+## Tracing
+
+The calculator code frequently calls the `record(<name>, ...);` procedure to record what is happening at that point.
+
+If you run the simulator with the command `<path>/sim/db48x -t<name>`, the recorder prints those trace messages (see also [Environment variables](#environment-variables) and [Options](#options)).
+
+## Post-mortem flight recorder dump
+
+In case of crash, a "recorder dump" will often provide useful information about what led to the crash, and should be attached to a bug report if it appears to contain useful information.
+
+You can also trigger a recorder dump using the F16 key in the simulator. On macOS, you can artificially trigger a recorder dump at any time by hitting Control-T from the terminal window, and on Linux by sending `SIGUSR1`, e.g. using `pkill -USR1 db48x`.

--- a/doc/0-Overview.md
+++ b/doc/0-Overview.md
@@ -825,6 +825,7 @@ Additional contributors to the project include (in order of appearance):
 * Ed van Gasteren (Ed@vanGasteren.net) (Bug fixes)
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
 * Jesus Cano (jcanovel@gmail.com) (bug fixes)
+* Riccardo Lucatuorto (gnuduncan@gmail.com)
 
 The authors would like to acknowledge
 

--- a/doc/0-Overview.md
+++ b/doc/0-Overview.md
@@ -824,6 +824,7 @@ Additional contributors to the project include (in order of appearance):
 * Thomas Eberhardt (sneakywumpus@gmail.com) (Bug fixes)
 * Ed van Gasteren (Ed@vanGasteren.net) (Bug fixes)
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
+* Jesus Cano (jcanovel@gmail.com) (bug fixes)
 
 The authors would like to acknowledge
 

--- a/doc/0-Overview.md
+++ b/doc/0-Overview.md
@@ -826,6 +826,7 @@ Additional contributors to the project include (in order of appearance):
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
 * Jesus Cano (jcanovel@gmail.com) (bug fixes)
 * Riccardo Lucatuorto (gnuduncan@gmail.com)
+* Ralf Ahlbrink (raprism@users.noreply.github.com)
 
 The authors would like to acknowledge
 

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -766,6 +766,7 @@ Additional contributors to the project include (in order of appearance):
 * Thomas Eberhardt (sneakywumpus@gmail.com) (Bug fixes)
 * Ed van Gasteren (Ed@vanGasteren.net) (Bug fixes)
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
+* Jesus Cano (jcanovel@gmail.com) (bug fixes)
 
 The authors would like to acknowledge
 

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -768,6 +768,7 @@ Additional contributors to the project include (in order of appearance):
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
 * Jesus Cano (jcanovel@gmail.com) (bug fixes)
 * Riccardo Lucatuorto (gnuduncan@gmail.com)
+* Ralf Ahlbrink (raprism@users.noreply.github.com)
 
 The authors would like to acknowledge
 

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -767,6 +767,7 @@ Additional contributors to the project include (in order of appearance):
 * Ed van Gasteren (Ed@vanGasteren.net) (Bug fixes)
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
 * Jesus Cano (jcanovel@gmail.com) (bug fixes)
+* Riccardo Lucatuorto (gnuduncan@gmail.com)
 
 The authors would like to acknowledge
 

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -775,6 +775,7 @@ Additional contributors to the project include (in order of appearance):
 * Thomas Eberhardt (sneakywumpus@gmail.com) (Bug fixes)
 * Ed van Gasteren (Ed@vanGasteren.net) (Bug fixes)
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
+* Jesus Cano (jcanovel@gmail.com) (bug fixes)
 
 The authors would like to acknowledge
 

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -777,6 +777,7 @@ Additional contributors to the project include (in order of appearance):
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
 * Jesus Cano (jcanovel@gmail.com) (bug fixes)
 * Riccardo Lucatuorto (gnuduncan@gmail.com)
+* Ralf Ahlbrink (raprism@users.noreply.github.com)
 
 The authors would like to acknowledge
 

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -776,6 +776,7 @@ Additional contributors to the project include (in order of appearance):
 * Ed van Gasteren (Ed@vanGasteren.net) (Bug fixes)
 * Jerome Ibanes (jibanes@gmail.com) (Dockerfile)
 * Jesus Cano (jcanovel@gmail.com) (bug fixes)
+* Riccardo Lucatuorto (gnuduncan@gmail.com)
 
 The authors would like to acknowledge
 

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -6173,6 +6173,7 @@ The documentation is generally well-written and comprehensive. The main issues a
 
 These are all straightforward to fix and would significantly improve consistency and accuracy.
 
+
 # Constants library
 
 The DB50X calculator features a library of constants covering mathematics,

--- a/sim/sim-main.cpp
+++ b/sim/sim-main.cpp
@@ -322,6 +322,7 @@ int main(int argc, char *argv[])
     if (install)
         copy(":/", files);
     QDir::setCurrent(files);
+    QDir::current().mkdir("screens");
 
     QApplication a(argc, argv);
     MainWindow w;

--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -823,13 +823,17 @@ void MainWindow::screenshot(cstring basename, int x, int y, int w, int h)
 //   Save a simulator screenshot under the "SCREEN" directory
 // ----------------------------------------------------------------------------
 {
-    QPixmap &screen = MainWindow::theScreen();
-    QPixmap img = screen.copy(x, y, w, h);
+    QString   name  = basename;
     QDateTime today = QDateTime::currentDateTime();
-    QString name = basename;
     name += today.toString("yyyyMMdd-hhmmss");
     name += ".png";
-    img.save(name, "PNG");
+
+    QPixmap &screen = MainWindow::theScreen();
+    QPixmap img = screen.copy(x, y, w, h);
+    bool ok = img.save(name, "PNG");
+    record(sim_window, "Screen capture %+s for %s",
+           ok ? "succeeded" : "failed",
+           name.toUtf8().constData());
 }
 
 

--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -532,6 +532,9 @@ void MainWindow::keyPressEvent(QKeyEvent * ev)
     int k = ev->key();
     record(sim_keys, "Key press %d", k);
 
+    if (k == Qt::Key_F16)
+        recorder_dump_for(tests::dump_on_fail);
+
     if (k == Qt::Key_F13 || k == Qt::Key_F14 || k == Qt::Key_F15 ||
         k == Qt::Key_F11 || k == Qt::Key_F12)
     {

--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -532,15 +532,15 @@ void MainWindow::keyPressEvent(QKeyEvent * ev)
     int k = ev->key();
     record(sim_keys, "Key press %d", k);
 
-    if (k == Qt::Key_F7 || k == Qt::Key_F8 || k == Qt::Key_F9 ||
+    if (k == Qt::Key_F13 || k == Qt::Key_F14 || k == Qt::Key_F15 ||
         k == Qt::Key_F11 || k == Qt::Key_F12)
     {
         if (!tests.isRunning())
         {
             tests.onlyCurrent = k == Qt::Key_F11;
-            tests.demo1 = k == Qt::Key_F7;
-            tests.demo2 = k == Qt::Key_F8;
-            tests.demo3 = k == Qt::Key_F9;
+            tests.demo1 = k == Qt::Key_F13;
+            tests.demo2 = k == Qt::Key_F14;
+            tests.demo3 = k == Qt::Key_F15;
             tests.start();
         }
         else

--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui.screen->setAttribute(Qt::WA_AcceptTouchEvents);
     ui.screen->installEventFilter(this);
     ui.keyboard->setStyleSheet("border-image: "
-                               "url(:/bitmap/keyboard-db48x.png) "
+                               "url(:/bitmap/keymap.png) "
                                "0 0 0 0 stretch stretch;");
 
     highlight = new Highlight(ui.keyboard);

--- a/src/algebraic.cc
+++ b/src/algebraic.cc
@@ -168,94 +168,9 @@ bool algebraic::hwfp_promotion(algebraic_g &x)
     uint prec = Settings.Precision();
     if (prec > 16)
         return false;
-    bool need_double = prec > 7;
-
-
-    id xt = x->type();
-    record(algebraic, "Real promotion of %p from %+s to hwfp",
-           (object_p) x, object::name(xt));
-
-    switch(xt)
-    {
-    case ID_hwfloat:
-        if (need_double)
-        {
-            x = hwdouble::make(hwfloat_p(+x)->value());
-            if (!x)
-                return false;
-        }
-        return true;
-    case ID_hwdouble:
-        if (!need_double)
-        {
-            x = hwfloat::make(hwdouble_p(+x)->value());
-            if (!x)
-                return false;
-        }
-        return true;
-    case ID_decimal:
-    case ID_neg_decimal:
-        if (need_double)
-            x = hwdouble::make(decimal_p(+x)->to_double());
-        else
-            x = hwfloat::make(decimal_p(+x)->to_float());
-        return x;
-
-    case ID_integer:
-        if (need_double)
-            x = as_hwfp(double(integer_p(+x)->value<ularge>()));
-        else
-            x = as_hwfp(float(integer_p(+x)->value<ularge>()));
-        return x;
-    case ID_neg_integer:
-        if (need_double)
-            x = as_hwfp(-double(integer_p(+x)->value<ularge>()));
-        else
-            x = as_hwfp(-float(integer_p(+x)->value<ularge>()));
-        return x;
-    case ID_bignum:
-    case ID_neg_bignum:
-        x = decimal::from_bignum(bignum_p(+x));
-        if (x && x->is_decimal())
-        {
-            if (need_double)
-                x = as_hwfp(decimal_p(+x)->to_double());
-            else
-                x = as_hwfp(decimal_p(+x)->to_float());
-        }
-        return x;
-
-    case ID_fraction:
-        if (need_double)
-            x = as_hwfp(double(fraction_p(+x)->numerator_value()) /
-                        double(fraction_p(+x)->denominator_value()));
-        else
-            x = as_hwfp(float(fraction_p(+x)->numerator_value()) /
-                        float(fraction_p(+x)->denominator_value()));
-        return x;
-    case ID_neg_fraction:
-        if (need_double)
-            x = as_hwfp(- double(fraction_p(+x)->numerator_value()) /
-                        double(fraction_p(+x)->denominator_value()));
-        else
-            x = as_hwfp(- float(fraction_p(+x)->numerator_value()) /
-                        float(fraction_p(+x)->denominator_value()));
-        return x;
-    case ID_big_fraction:
-    case ID_neg_big_fraction:
-        x = decimal::from_big_fraction(big_fraction_p(+x));
-        if (x && x->is_decimal())
-        {
-            if (need_double)
-                x = as_hwfp(decimal_p(+x)->to_double());
-            else
-                x = as_hwfp(decimal_p(+x)->to_float());
-        }
-        return x;
-    default:
-        return false;
-    }
+    return prec > 7 ? to_hwdouble(x) : to_hwfloat(x);
 }
+
 
 bool algebraic::complex_promotion(algebraic_g &x, object::id type)
 // ----------------------------------------------------------------------------
@@ -730,6 +645,122 @@ bool algebraic::to_decimal(algebraic_g &x, bool weak)
             rt.type_error();
     }
     return false;
+}
+
+
+bool algebraic::to_hwfloat(algebraic_g &x)
+// ----------------------------------------------------------------------------
+//   Promote the value x to a hardware floating-point type if possible
+// ----------------------------------------------------------------------------
+{
+    if (!x)
+        return false;
+
+    id xt = x->type();
+    record(algebraic, "Convert %p from %+s to hwfloat",
+           (object_p) x, object::name(xt));
+
+    switch(xt)
+    {
+    case ID_hwfloat:
+        return true;
+    case ID_hwdouble:
+        x = hwfloat::make(hwdouble_p(+x)->as_float());
+        return x;
+
+    case ID_decimal:
+    case ID_neg_decimal:
+        x = hwfloat::make(decimal_p(+x)->to_float());
+        return x;
+
+    case ID_integer:
+        x = as_hwfp(float(integer_p(+x)->value<ularge>()));
+        return x;
+    case ID_neg_integer:
+        x = as_hwfp(-float(integer_p(+x)->value<ularge>()));
+        return x;
+    case ID_bignum:
+    case ID_neg_bignum:
+        x = decimal::from_bignum(bignum_p(+x));
+        if (x && x->is_decimal())
+            x = as_hwfp(decimal_p(+x)->to_float());
+        return x;
+
+    case ID_fraction:
+        x = as_hwfp(float(fraction_p(+x)->numerator_value()) /
+                    float(fraction_p(+x)->denominator_value()));
+        return x;
+    case ID_neg_fraction:
+        x = as_hwfp(-float(fraction_p(+x)->numerator_value()) /
+                    float(fraction_p(+x)->denominator_value()));
+        return x;
+    case ID_big_fraction:
+    case ID_neg_big_fraction:
+        x = decimal::from_big_fraction(big_fraction_p(+x));
+        if (x && x->is_decimal())
+                x = as_hwfp(decimal_p(+x)->to_float());
+        return x;
+    default:
+        return false;
+    }
+}
+
+
+bool algebraic::to_hwdouble(algebraic_g &x)
+// ----------------------------------------------------------------------------
+//   Promote the value x to a hardware floating-point type if possible
+// ----------------------------------------------------------------------------
+{
+    if (!x)
+        return false;
+
+    id xt = x->type();
+    record(algebraic, "Convert %p from %+s to hwdouble",
+           (object_p) x, object::name(xt));
+
+    switch(xt)
+    {
+    case ID_hwfloat:
+        x = hwfloat::make(hwfloat_p(+x)->as_double());
+        return x;
+    case ID_hwdouble:
+        return true;
+
+    case ID_decimal:
+    case ID_neg_decimal:
+        x = hwdouble::make(decimal_p(+x)->to_double());
+        return x;
+
+    case ID_integer:
+        x = as_hwfp(double(integer_p(+x)->value<ularge>()));
+        return x;
+    case ID_neg_integer:
+        x = as_hwfp(-double(integer_p(+x)->value<ularge>()));
+        return x;
+    case ID_bignum:
+    case ID_neg_bignum:
+        x = decimal::from_bignum(bignum_p(+x));
+        if (x && x->is_decimal())
+            x = as_hwfp(decimal_p(+x)->to_double());
+        return x;
+
+    case ID_fraction:
+        x = as_hwfp(double(fraction_p(+x)->numerator_value()) /
+                    double(fraction_p(+x)->denominator_value()));
+        return x;
+    case ID_neg_fraction:
+        x = as_hwfp(-double(fraction_p(+x)->numerator_value()) /
+                    double(fraction_p(+x)->denominator_value()));
+        return x;
+    case ID_big_fraction:
+    case ID_neg_big_fraction:
+        x = decimal::from_big_fraction(big_fraction_p(+x));
+        if (x && x->is_decimal())
+                x = as_hwfp(decimal_p(+x)->to_double());
+        return x;
+    default:
+        return false;
+    }
 }
 
 

--- a/src/algebraic.h
+++ b/src/algebraic.h
@@ -83,6 +83,10 @@ struct algebraic : command
         return x && (!x->is_big() || to_decimal(x));
     }
 
+    // Convert to hw floating point if possible
+    static bool to_hwfloat(algebraic_g &x);
+    static bool to_hwdouble(algebraic_g &x);
+
     // Marking that we are talking about angle units
     typedef id angle_unit;
 
@@ -120,11 +124,12 @@ struct algebraic : command
     // Function pointers used by generic evaluation code
     typedef decimal_p (*decimal_fn)(decimal_r x);
 
-    template<typename value>
+    template <typename value>
     static algebraic_p as_hwfp(value x);
     // -------------------------------------------------------------------------
     //   Return a hardware floating-point value if possible
     // -------------------------------------------------------------------------
+
 
     bool is_numeric_constant() const;
     algebraic_p as_numeric_constant() const;

--- a/src/arithmetic.cc
+++ b/src/arithmetic.cc
@@ -154,7 +154,9 @@ algebraic_p arithmetic::optimize<add>(algebraic_r x, algebraic_r y)
                 rt.undefined_operation_error();
                 return nullptr;
             }
-            return xinf ? x : y;
+            if ((xinf && y->is_algebraic_num()) ||
+                (yinf && x->is_algebraic_num()))
+                return xinf ? x : y;
         }
         if  (x->is_simplifiable() && y->is_simplifiable())
         {
@@ -401,7 +403,8 @@ algebraic_p arithmetic::optimize<subtract>(algebraic_r x, algebraic_r y)
                 rt.undefined_operation_error();
                 return nullptr;
             }
-            return xinf ? +x : rt.infinity(yinf > 0);
+            if (x->is_algebraic_num() || y->is_algebraic_num())
+              return xinf ? +x : rt.infinity(yinf > 0);
         }
         if  (x->is_simplifiable() && y->is_simplifiable())
         {
@@ -593,7 +596,8 @@ algebraic_p arithmetic::optimize<multiply>(algebraic_r x, algebraic_r y)
                 rt.undefined_operation_error();
                 return nullptr;
             }
-            return rt.infinity(x->is_negative() ^ y->is_negative());
+            if (x->is_algebraic_num() || y->is_algebraic_num())
+              return rt.infinity(x->is_negative(false) ^ y->is_negative(false));
         }
 
         if (x->is_simplifiable() && y->is_simplifiable())
@@ -787,10 +791,10 @@ algebraic_p arithmetic::optimize<divide>(algebraic_r x, algebraic_r y)
                 rt.undefined_operation_error();
                 return nullptr;
             }
-            if (yinf && x->is_real())
+            if (yinf && x->is_algebraic_num())
                 return integer::make(0);            // 1 / ∞ = 0
-            if (xinf && y->is_real())
-                return rt.infinity((xinf < 0) ^ y->is_negative());
+            if (xinf && y->is_algebraic_num())
+                return rt.infinity((xinf < 0) ^ y->is_negative(false));
         }
 
         if (x->is_simplifiable() && y->is_simplifiable())
@@ -1162,22 +1166,51 @@ algebraic_p arithmetic::optimize<struct pow>(algebraic_r x, algebraic_r y)
         return integer::make(1);
     }
 
-    int xinf = x->is_infinity();
-    int yinf = y->is_infinity();
-    if (xinf || yinf)
+    if (Settings.AutoSimplify())
     {
-        if (xinf > 0 && yinf > 0)
-            return rt.infinity(false);
-        if (xinf > 0 && y->is_real() && !y->is_zero())
-            return y->is_negative()
-                ? algebraic_p(integer::make(0))
-                : +x;
-        if (x->is_real() && !x->is_negative() && !x->is_zero() && yinf)
-            return yinf < 0
-                ? algebraic_p(integer::make(0))
-                : rt.infinity(false);
-        rt.undefined_operation_error();
-        return nullptr;
+        int xinf = x->is_infinity();
+        int yinf = y->is_infinity();
+        if (xinf || yinf)
+        {
+            if ((x->is_negative(false) && yinf) ||
+                (yinf < 0 && (xinf || x->is_zero(false))))
+            {
+                rt.undefined_operation_error();
+                return nullptr;
+            }
+            if (xinf && yinf)
+                return rt.infinity(false);
+            if (y->is_negative(false))
+                return algebraic_p(integer::make(0));
+            if (y->is_algebraic_num())
+            {
+                bool yzero = y->is_zero();
+                if (xinf > 0 && !yzero)
+                {
+                    return +x;
+                }
+                else if (y->is_integer() && !yzero)
+                {
+                    large yi = y->as_int64(0, false);
+                    return rt.infinity(yi % 2);
+                }
+                else
+                {
+                    rt.undefined_operation_error();
+                    return nullptr;
+                }
+            }
+            else if (yinf && x->is_algebraic_num())
+            {
+                if (x->is_zero())
+                {
+                    rt.undefined_operation_error();
+                    return nullptr;
+                }
+                return yinf < 0 ? algebraic_p(integer::make(0))
+                    : rt.infinity(false);
+            }
+        }
     }
 
     // Deal with X^N where N is a positive  or negative integer

--- a/src/complex.cc
+++ b/src/complex.cc
@@ -1266,13 +1266,14 @@ COMPLEX_BODY(ln1p)
     return ln(one + z);
 }
 
+
 COMPLEX_BODY(expm1)
 // ----------------------------------------------------------------------------
 //   Complex implementation of expm1
 // ----------------------------------------------------------------------------
 {
     complex_g one = complex::make(1, 0);
-    return exp(z - one);
+    return exp(z) - one;
 }
 
 

--- a/src/graphics.cc
+++ b/src/graphics.cc
@@ -1152,6 +1152,88 @@ static coord show_x       = 0;
 static coord show_y       = 0;
 static coord show_delta   = 8;
 
+static void draw_show_horizontal_arrow(coord tipx, coord tipy,
+                                       coord size, coord padding,
+                                       bool right, pattern fc, pattern bc)
+// ----------------------------------------------------------------------------
+//   Draw a left/right pointing arrow with tip at (tipx, tipy)
+// ----------------------------------------------------------------------------
+//   tipx, tipy: Arrow tip coordinates on screen (assuming the padding is 0)
+//   size:       Arrow size in pixels
+//   padding:    Extra pixels around the arrow body
+//   right:      true for a right arrow, false for a left arrow
+//   fc:         Foreground pattern for the arrow
+//   bc:         Background pattern behind the arrow
+{
+    Screen.fill(right ? tipx - size - 2*padding: tipx,
+                tipy - size - padding,
+                right ? tipx : tipx + size + 2*padding,
+                tipy + size + padding,
+                bc);
+    for (coord offset = 0; offset < size; offset++)
+    {
+        coord span = offset + 1;
+        coord x = right ? tipx - offset - padding : tipx + offset + padding;
+        Screen.fill(x, tipy - span + 1, x, tipy + span - 1, fc);
+    }
+}
+
+
+
+static void draw_show_vertical_arrow(coord tipx, coord tipy,
+                                     coord size, coord padding,
+                                     bool down, pattern fc, pattern bc)
+// ----------------------------------------------------------------------------
+//   Draw an up/down pointing arrow with tip at (tipx, tipy)
+// ----------------------------------------------------------------------------
+//   tipx, tipy: Arrow tip coordinates on screen (assuming padding is 0)
+//   size:       Arrow size in pixels
+//   padding:    Extra pixels around the arrow body
+//   down:       true for a down arrow, false for an up arrow
+//   fc:         Foreground pattern for the arrow
+//   bc:         Background pattern behind the arrow
+{
+    Screen.fill(tipx - size - padding,
+                down ? tipy - size - 2*padding : tipy,
+                tipx + size + padding,
+                down ? tipy : tipy + size + 2*padding,
+                bc);
+    for (coord offset = 0; offset < size; offset++)
+    {
+        coord span = offset + 1;
+        coord y = down ? tipy - offset - padding : tipy + offset + padding;
+        Screen.fill(tipx - span + 1, y, tipx + span - 1, y, fc);
+    }
+}
+
+
+static void draw_show_arrows(grob::pixsize width, grob::pixsize height)
+// ----------------------------------------------------------------------------
+//   Render navigation arrows if the grob object is bigger than the display
+// ----------------------------------------------------------------------------
+//   width, height: Size of the full grob being shown
+{
+    auto        fc            = Settings.Foreground();
+    auto        bc            = pattern::gray90;
+    const coord arrow_size    = 6;
+    const coord arrow_padding = 2;
+    coord       midx          = LCD_W / 2;
+    coord       midy          = LCD_H / 2;
+
+    if (show_x > 0)
+        draw_show_horizontal_arrow(0, midy, arrow_size, arrow_padding,
+                                   false, fc, bc);
+    if (show_x + LCD_W < coord(width))
+        draw_show_horizontal_arrow(LCD_W - 1, midy, arrow_size, arrow_padding,
+                                   true, fc, bc);
+    if (show_y > 0)
+        draw_show_vertical_arrow(midx, 0, arrow_size, arrow_padding,
+                                 false, fc, bc);
+    if (show_y + LCD_H < coord(height))
+        draw_show_vertical_arrow(midx, LCD_H - 1, arrow_size, arrow_padding,
+                                 true, fc, bc);
+}
+
 
 void show_grob(grob_p graph)
 // ----------------------------------------------------------------------------
@@ -1179,6 +1261,7 @@ void show_grob(grob_p graph)
         grob::surface s = graph->pixels();
         Screen.copy(s, r, point(show_x,show_y));
     }
+    draw_show_arrows(width, height);
     mark_dirty(0, 0, LCD_W-1, LCD_H-1);
     refresh_dirty();
 }

--- a/src/graphics.cc
+++ b/src/graphics.cc
@@ -1325,6 +1325,8 @@ object::result show(object_r obj)
 #endif // SIMULATOR && !WASM
             }
         }
+        show_x = 0;
+        show_y = 0;
         sys_timer_disable(TIMER0);
         sys_timer_disable(TIMER1);
         redraw_lcd(true);

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -10499,6 +10499,49 @@ void tests::infinity_and_undefined()
         .test(CLEAR, "1/3 0", ENTER, ID_divide)
         .error("Divide by zero");
 
+
+    step("Infinity with complex add")
+        .test(CLEAR, "Ⓒ∞ 2+3ⅈ", ENTER, ID_add)
+        .expect("∞")
+        .test(CLEAR, "2+3ⅈ Ⓒ∞ ", ENTER, ID_add)
+        .expect("∞");
+    step("Infinity with complex sub")
+        .test(CLEAR, "Ⓒ∞ 2+3ⅈ", ENTER, ID_subtract)
+        .expect("∞")
+        .test(CLEAR, "2+3ⅈ Ⓒ∞ ", ENTER, ID_subtract)
+        .expect("−∞");
+    step("Infinity with complex multiply")
+        .test(CLEAR, "Ⓒ∞ 2+3ⅈ", ENTER, ID_multiply)
+        .expect("∞")
+        .test(CLEAR, "2+3ⅈ Ⓒ∞ ", ENTER, ID_multiply)
+        .expect("∞");
+    step("Infinity with complex divide")
+        .test(CLEAR, "Ⓒ∞ 2+3ⅈ", ENTER, ID_divide)
+        .expect("∞")
+        .test(CLEAR, "2+3ⅈ Ⓒ∞ ", ENTER, ID_divide)
+        .expect("0");
+
+    step("Infinity with arithmetic add")
+        .test(CLEAR, "Ⓒ∞ '12+43'", ENTER, ID_add)
+        .expect("'∞+(12+43)'")
+        .test(CLEAR, "'12+43' Ⓒ∞ ", ENTER, ID_add)
+        .expect("'12+43+∞'");
+    step("Infinity with arithmetic sub")
+        .test(CLEAR, "Ⓒ∞ '12+43'", ENTER, ID_subtract)
+        .expect("'∞-(12+43)'")
+        .test(CLEAR, "'12+43' Ⓒ∞ ", ENTER, ID_subtract)
+        .expect("'12+43-∞'");
+    step("Infinity with arithmetic multiply")
+        .test(CLEAR, "Ⓒ∞ '12+43'", ENTER, ID_multiply)
+        .expect("'∞·(12+43)'")
+        .test(CLEAR, "'12+43' Ⓒ∞ ", ENTER, ID_multiply)
+        .expect("'(12+43)·∞'");
+    step("Infinity with arithmetic divide")
+        .test(CLEAR, "Ⓒ∞ '12+43'", ENTER, ID_divide)
+        .expect("'∞÷(12+43)'")
+        .test(CLEAR, "'12+43' Ⓒ∞ ", ENTER, ID_divide)
+        .expect("'(12+43)÷∞'");
+
     test(CLEAR);
 }
 
@@ -11090,9 +11133,9 @@ void tests::constants_menu()
         .test(CLEAR, DIRECT("0 −∞ /"), ENTER).expect("0");
     step("Power infinities")
         .test(CLEAR, DIRECT("∞ 42 ^"), ENTER).expect("∞")
-        .test(CLEAR, DIRECT("−∞ 42 ^"), ENTER).error("Undefined operation")
+        .test(CLEAR, DIRECT("−∞ 42 ^"), ENTER).expect("∞")
         .test(CLEAR, DIRECT("∞ -42 ^"), ENTER).expect("0")
-        .test(CLEAR, DIRECT("−∞ -42 ^"), ENTER).error("Undefined operation")
+        .test(CLEAR, DIRECT("−∞ -42 ^"), ENTER).expect("0")
         .test(CLEAR, DIRECT("42 ∞ ^"), ENTER).expect("∞")
         .test(CLEAR, DIRECT("42 −∞ ^"), ENTER).expect("0")
         .test(CLEAR, DIRECT("-42 ∞ ^"), ENTER).error("Undefined operation")

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -5101,6 +5101,18 @@ void tests::complex_functions()
     test(ID_exp)
         .expect("18.43908 89145 85774 62∡0.86217 00546 67226 34884ʳ");
 
+    step("Complex exponential minus 1 (zero)");
+    test(CLEAR, "0+0ⅈ expm1", ENTER)
+        .expect("0+0ⅈ");  // expm1(0) = e^0 - 1 = 0
+
+    step("Complex exponential minus 1 (real)");
+    test(CLEAR, "1+0ⅈ expm1", ENTER)
+        .match("1\\.71828.*\\+0ⅈ");  // e - 1
+
+    step("Complex exponential minus 1 (imaginary)");
+    test(CLEAR, "0+3.14159265358979323846ⅈ expm1", ENTER)
+        .match("-2\\..*ⅈ");  // expm1(πi) ≈ -2 (with tiny floating point error)
+
     step("Power");
     test(CLEAR, "3+7ⅈ", ENTER, "2-3ⅈ", ID_pow)
         .expect("1 916.30979 15541 96293 8∡2.52432 98723 79583 8639ʳ");

--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -673,7 +673,7 @@ bool user_interface::key(int key, bool repeating, bool talpha)
     if (rt.editing())
         update_mode();
 
-    if (!skey && last != KEY_SHIFT)
+    if (!skey && last != KEY_SHIFT && !transalpha)
     {
         shift = false;
         xshift = false;
@@ -4119,6 +4119,10 @@ bool user_interface::noHelpForKey(int key)
             key != KEY_SUB && key != KEY_MUL && key != KEY_DIV && key != KEY_RUN)
             return true;
     }
+
+    // No help for shifted UP/DOWN (history, edit, etc)
+    if (key == KEY_UP || key == KEY_DOWN)
+        return true;
 
     // Other cases are regular functions, we can display help
     return false;

--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -75,6 +75,7 @@ RECORDER(menus,         16, "Menu operations");
 RECORDER(help,          16, "On-line help");
 RECORDER(help_search,   16, "On-line help topic search");
 RECORDER(tests_ui,      16, "Test interaction with user interface");
+RECORDER(shifts,        16, "Shift logic (including transient alpha)");
 RECORDER(keymap_warning, 8, "Warnings about invalid keymaps");
 
 #define NUM_TOPICS      (sizeof(topics) / sizeof(topics[0]))
@@ -4330,6 +4331,12 @@ bool user_interface::handle_shifts(int &key, bool talpha)
 {
     bool consumed = false;
 
+    record(shifts, "Key %d%+s%+s%+s",
+           key,
+           talpha       ? " talpha"    : "",
+           delayedArrow ? " delayed"   : "",
+           longpress    ? " longpress" : "");
+
     // Transient alpha management
     if (!transalpha)
     {
@@ -4338,13 +4345,6 @@ bool user_interface::handle_shifts(int &key, bool talpha)
         {
             if (key == KEY_UP || key == KEY_DOWN)
             {
-                // Let menu and normal keys go through
-                if (xshift)
-                {
-                    last = key;
-                    return false;
-                }
-
                 repeat = true;
 
                 // Delay processing of up or down until after delay
@@ -4383,6 +4383,10 @@ bool user_interface::handle_shifts(int &key, bool talpha)
             last = 0;
             return false;
         }
+        else
+        {
+            delayedArrow = false;
+        }
     }
     else
     {
@@ -4399,6 +4403,7 @@ bool user_interface::handle_shifts(int &key, bool talpha)
             }
             key = 0;
             last = 0;
+            delayedArrow = false;
             return true;
         }
         else if (key == KEY_UP || key == KEY_DOWN || key == 0)

--- a/src/user_interface.cc
+++ b/src/user_interface.cc
@@ -6148,7 +6148,7 @@ bool user_interface::do_decimal_separator()
                 ed = rt.editor();
                 if (cursor + 4 <= edlen &&
                     (memcmp(ed + cursor, "_dms", 4) == 0 ||
-                        memcmp(ed + cursor, "_hms", 4) == 0))
+                     memcmp(ed + cursor, "_hms", 4) == 0))
                     remove(cursor, 4);
             }
             else
@@ -6173,7 +6173,7 @@ bool user_interface::do_decimal_separator()
             ed = rt.editor();
             if (cursor + 4 > edlen ||
                 (memcmp(ed + cursor, "_dms", 4) != 0 &&
-                    memcmp(ed + cursor, "_hms", 4) != 0))
+                 memcmp(ed + cursor, "_hms", 4) != 0))
             {
                 size_t add = insert(cursor, utf8("_dms"), 4);
                 cursor -= add;

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -308,7 +308,7 @@ inline bool utf8_whitespace(unicode cp)
 //   Check if something is a whitespace
 // ----------------------------------------------------------------------------
 {
-    return cp == ' ' || cp == '\n' || cp == '\t';
+    return cp == ' ' || cp == '\n' || cp == '\r' || cp == '\t';
 }
 
 


### PR DESCRIPTION
simulator: Refer to keyboard image using alias keymap.png

sim/sim-window.cpp:MainWindow::MainWindow set a border-image URL referring to the keymap image using the actual file name which works in the desktop case. However, Android bundles are strict about resources and the correct way to refer to the image is using the alias keymap.png. This change enables the keyboard to be displayed both on desktop and Android devices like phones.