### PR TITLE
Fix PartsMenu label for ToRelativeUncertainty

### DIFF
--- a/doc/5-ReleaseNotes.md
+++ b/doc/5-ReleaseNotes.md
@@ -1,5 +1,40 @@
 # Release notes
 
+## Release 0.9.16 - Factorization, precision fixes, and documentation
+
+This release adds prime and factorization features, improves numeric precision,
+and expands simulator and user documentation.
+
+### New features
+
+* Add `IsPrime`, `Factors`, `PrevPrime` and `NextPrime` commands
+* Add `MaxFactorsBits` and `MaxFactorIterations` settings for factorization
+* Add `TRIGSIN` command for Pythagorean identity rewrites
+* Add a Unix man page and simulator documentation
+* Add simulator recorder dump on `F16`; move demo playback to `F13`-`F15`
+* Paint navigation arrows in `SHOW`
+* Accept `CR/LF` line endings when reading Windows files
+
+### Bug fixes
+
+* Fix `expm1` precision loss for small arguments, including complex values
+* Fix `ln1p` precision loss for small arguments
+* Fix shift behavior after transient alpha, and support shift/xshift for transalpha
+* Reset `show_x` and `show_y` when exiting `SHOW`
+* Ensure the simulator creates the `screens` directory when needed
+* Fix an infinity optimization regression in arithmetic
+* Add missing null-dereference checks in factorization code
+
+### Enhancements
+
+* Refactor and optimize the decimal factorization code path, with expanded tests
+* Add conversion support to `float` and `double` in algebraic code
+* Update to recorder v1.2.3
+* Add documentation updates (DeepWiki reference, legal notice updates)
+* Add build preparation for upcoming make-it-quick integration
+* Welcome several new authors to the team, see AUTHORS file
+* Add LEGAL-NOTICE.md about compliance with California and Colorado laws
+
 ## Release 0.9.15 "Myriam" - GitHub automation, portability
 
 This release focused on GitHub and GitLab automation

--- a/help/db48x.md
+++ b/help/db48x.md
@@ -4337,6 +4337,41 @@ To enter `IFTE` in a program, select the `TestsMenu` (🟦 _3_) and then
 the _IFTE_ command (🟨 _F6_).
 # Release notes
 
+## Release 0.9.16 - Factorization, precision fixes, and documentation
+
+This release adds prime and factorization features, improves numeric precision,
+and expands simulator and user documentation.
+
+### New features
+
+* Add `IsPrime`, `Factors`, `PrevPrime` and `NextPrime` commands
+* Add `MaxFactorsBits` and `MaxFactorIterations` settings for factorization
+* Add `TRIGSIN` command for Pythagorean identity rewrites
+* Add a Unix man page and simulator documentation
+* Add simulator recorder dump on `F16`; move demo playback to `F13`-`F15`
+* Paint navigation arrows in `SHOW`
+* Accept `CR/LF` line endings when reading Windows files
+
+### Bug fixes
+
+* Fix `expm1` precision loss for small arguments, including complex values
+* Fix `ln1p` precision loss for small arguments
+* Fix shift behavior after transient alpha, and support shift/xshift for transalpha
+* Reset `show_x` and `show_y` when exiting `SHOW`
+* Ensure the simulator creates the `screens` directory when needed
+* Fix an infinity optimization regression in arithmetic
+* Add missing null-dereference checks in factorization code
+
+### Enhancements
+
+* Refactor and optimize the decimal factorization code path, with expanded tests
+* Add conversion support to `float` and `double` in algebraic code
+* Update to recorder v1.2.3
+* Add documentation updates (DeepWiki reference, legal notice updates)
+* Add build preparation for upcoming make-it-quick integration
+* Welcome several new authors to the team, see AUTHORS file
+* Add LEGAL-NOTICE.md about compliance with California and Colorado laws
+
 ## Release 0.9.15 "Myriam" - GitHub automation, portability
 
 This release focused on GitHub and GitLab automation

--- a/help/db50x.md
+++ b/help/db50x.md
@@ -4346,6 +4346,41 @@ To enter `IFTE` in a program, select the `TestsMenu` (🟦 _3_) and then
 the _IFTE_ command (🟨 _F6_).
 # Release notes
 
+## Release 0.9.16 - Factorization, precision fixes, and documentation
+
+This release adds prime and factorization features, improves numeric precision,
+and expands simulator and user documentation.
+
+### New features
+
+* Add `IsPrime`, `Factors`, `PrevPrime` and `NextPrime` commands
+* Add `MaxFactorsBits` and `MaxFactorIterations` settings for factorization
+* Add `TRIGSIN` command for Pythagorean identity rewrites
+* Add a Unix man page and simulator documentation
+* Add simulator recorder dump on `F16`; move demo playback to `F13`-`F15`
+* Paint navigation arrows in `SHOW`
+* Accept `CR/LF` line endings when reading Windows files
+
+### Bug fixes
+
+* Fix `expm1` precision loss for small arguments, including complex values
+* Fix `ln1p` precision loss for small arguments
+* Fix shift behavior after transient alpha, and support shift/xshift for transalpha
+* Reset `show_x` and `show_y` when exiting `SHOW`
+* Ensure the simulator creates the `screens` directory when needed
+* Fix an infinity optimization regression in arithmetic
+* Add missing null-dereference checks in factorization code
+
+### Enhancements
+
+* Refactor and optimize the decimal factorization code path, with expanded tests
+* Add conversion support to `float` and `double` in algebraic code
+* Update to recorder v1.2.3
+* Add documentation updates (DeepWiki reference, legal notice updates)
+* Add build preparation for upcoming make-it-quick integration
+* Welcome several new authors to the team, see AUTHORS file
+* Add LEGAL-NOTICE.md about compliance with California and Colorado laws
+
 ## Release 0.9.15 "Myriam" - GitHub automation, portability
 
 This release focused on GitHub and GitLab automation

--- a/src/dm32/qspi_crc.h
+++ b/src/dm32/qspi_crc.h
@@ -1,4 +1,4 @@
 
-#define QSPI_DATA_SIZE   296276
+#define QSPI_DATA_SIZE   296852
 #define QSPI_DATA_CRC  0x000cfed6
 

--- a/src/dm42/qspi_crc.h
+++ b/src/dm42/qspi_crc.h
@@ -1,4 +1,4 @@
 
-#define QSPI_DATA_SIZE   292236
+#define QSPI_DATA_SIZE   292812
 #define QSPI_DATA_CRC  0x000cfed6
 

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -442,7 +442,7 @@ MENU(PartsMenu,
      "StdRnd",  ID_StandardRound,
      "RelRnd",  ID_RelativeRound,
      "→StdUnc", ID_ToStandardUncertainty,
-     "→RelRnd", ID_ToRelativeUncertainty,
+     "→RelUnc", ID_ToRelativeUncertainty,
      "PrcRnd",  ID_PrecisionRound
 );
 

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -11485,6 +11485,9 @@ void tests::constants_menu()
         .test(CLEAR, "5.36248084521_kg 0.11_cm", ENTER,
               ID_PartsMenu, ID_StandardRound)
         .error("Inconsistent units");
+    step("Parts menu uncertainty labels")
+        .test(CLEAR, ID_PartsMenu, F6, F6)
+        .image_menus("parts-menu-labels", 2);
 
     step("Use Const command from command line")
         .test(CLEAR, "'c' CONST", ENTER, ID_ToDecimal)


### PR DESCRIPTION
## Summary
- Fixed menu label in `PartsMenu`: `→RelRnd` → `→RelUnc` for `ToRelativeUncertainty`
- Added regression test for parts menu label spelling

Fixes #1625